### PR TITLE
Add a Quick Start section to README.md

### DIFF
--- a/KiBOM_CLI.py
+++ b/KiBOM_CLI.py
@@ -1,3 +1,13 @@
+"""
+    @package
+    Generate BOM in xml, csv, txt, tsv or html formats.
+    Rows are sorted.
+    Rows are grouped (summed to Quantity, and References) 
+    by Value, Footprint, and optional fields, typically Vendor and SKU.
+    Fields are Description, Part, References, Value, Footprint, Quantity, Datasheet.
+    Configurable by a config file .ini
+"""
+
 from __future__ import print_function
 
 import re

--- a/KiBOM_CLI.py
+++ b/KiBOM_CLI.py
@@ -27,6 +27,15 @@ def close(*arg):
 def say(*arg):
     if verbose:
         print(*arg)
+
+def isExtensionSupported(filename):
+    result = False
+    extensions = [".xml",".csv",".txt",".tsv",".html"]
+    for e in extensions:
+        if filename.endswith(e):
+            result = True
+            break
+    return result
     
 parser = argparse.ArgumentParser(description="KiBOM Bill of Materials generator script")
 
@@ -117,16 +126,10 @@ if write_to_bom:
 
     if output_file is None:
         output_file = input_file.replace(".xml","_bom.csv")
-       
-    #enfore a proper extension
-    valid = False
-    extensions = [".xml",".csv",".txt",".tsv",".html"]
-    for e in extensions:
-        if output_file.endswith(e):
-            valid = True
-            break
-    if not valid:
-        close("Extension must be one of",extensions)
+    
+    # KiCad BOM dialog by default passes "%O" without an extension.  Append our default 
+    if not isExtensionSupported(output_file):
+        output_file += "_bom.csv"
        
     output_file = os.path.abspath(output_file)
 

--- a/README.md
+++ b/README.md
@@ -58,6 +58,16 @@ To run from KiCad, simply add the same command line in the *Bill of Materials* s
 
 ![alt tag](example/html_ex.png?raw=True "HTML Example")
 
+## Quick Start
+
+Download and unzip the files almost anywhere.  
+
+When you start the KiCad schematic editor and choose *Tools>Generate Bill of Materials* expect a *Bill of Material* dialog.  Choose the *Add Plugin* button, expect a file chooser dialog.  Navigate to where you unzipped the files, select the KiBOM_CLI.py file, and choose the *Open* button.  Expect another confirmation dialog and choose *OK*.  Expect the *Command Line:* text box to be filled in, and for a description of the plugin to appear in the *Plugin Info* text box.  Choose the *Generate* button.  Expect some messages in the *Plugin Info* text box, and for a .csv file to exist in your KiCad project directory.
+
+If you want other than .csv format, edit the *Command Line*, for example inserting ".html" after the "%O".
+
+If you want more columns in your BOM, before you generate your BOM, in the schematic editor choose *Preferences>Schematic Editor Options*  and create new rows in the *Template Field Names* tab.  Then edit your components and fill in the fields.  KiBOM will reasonably sum rows in the BOM having the same values in your fields.  For example, if you have two components both with Vendor=Digikey and SKU=877-5309 (and value and footprints equal), there will be one row with Quantity "2" and References e.g. "R1, R2."
+
 ## Features
 
 ### Intelligent Component Grouping


### PR DESCRIPTION
I think a Quick Start is needed because many users won't want to use all the features, they just want to test it.  Almost an Installation section since  the installation might be a little different for various platforms (I am on Ubuntu, the BOM dialog opened a file chooser on /usr/bin, which I didn't expect, but I found that I could navigate to wherever I had unzipped.  Maybe the next version of KiCad will default to a standard location for plugins, or maybe Ubuntu messed it up.)

Also, you might want a little more context for users.  My use case is I want to order from Digikey.  (And I quickly learned that KiBOM did exactly the right thing.)  Another use case is to pull from your own inventory.  Another use case might just be a list for assembly instructions.

Of course, edit or reject as you see fit.

And once again, many thanks.