### PR TITLE
Prioritize component fields over library fields

### DIFF
--- a/KiBOM/component.py
+++ b/KiBOM/component.py
@@ -284,8 +284,11 @@ class Component():
     def getTimestamp(self):
         return self.element.get("tstamp")
 
-    def getDescription(self):
-        return self.libpart.getDescription()
+    def getDescription(self, libraryToo=True):
+        ret = self.element.get("field", "name", "Description")
+        if ret =="" and libraryToo:
+            ret = self.libpart.getDescription()
+        return ret
 
 class ComponentGroup():
 

--- a/KiBOM/component.py
+++ b/KiBOM/component.py
@@ -276,7 +276,10 @@ class Component():
         return ret
 
     def getDatasheet(self, libraryToo=True):
-        return self.libpart.getDatasheet()
+        ret = self.element.get("datasheet")
+        if ret =="" and libraryToo:
+            ret = self.libpart.getDatasheet()
+        return ret
 
     def getTimestamp(self):
         return self.element.get("tstamp")


### PR DESCRIPTION
This pull request prioritizes the `Description` and `Datasheet` field of a component over the value defined in the library.

I use this because often times a part like a "Resistor" has a useless datasheet and description in the library.  Instead I can link to the actual datasheet to the component and a useful description such as `RES SMD 10K 1% 0201 1/16W`.

Thanks!