### PR TITLE
Added CSV separator override option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-**.pyc
+*.pyc
 
 *.kicad_mod
 .idea/

--- a/KiBOM/csv_writer.py
+++ b/KiBOM/csv_writer.py
@@ -20,12 +20,16 @@ def WriteCSV(filename, groups, net, headings, prefs):
     filename = os.path.abspath(filename)
     
     #delimeter is assumed from file extension
-    if filename.endswith(".csv"):
-        delimiter = ","
-    elif filename.endswith(".tsv") or filename.endswith(".txt"):
-        delimiter = "\t"
+	#override delimiter if separator specified
+    if prefs.separatorCSV != None:
+        delimiter = prefs.separatorCSV
     else:
-        return False
+        if filename.endswith(".csv"):
+            delimiter = ","
+        elif filename.endswith(".tsv") or filename.endswith(".txt"):
+            delimiter = "\t"
+        else:
+            return False
         
     nGroups = len(groups)
     nTotal = sum([g.getCount() for g in groups])

--- a/KiBOM/preferences.py
+++ b/KiBOM/preferences.py
@@ -41,7 +41,7 @@ class BomPref:
         self.verbose = False #by default, is not verbose
         self.configField = "Config" #default field used for part fitting config
         self.pcbConfig = "default"
-            
+        self.separatorCSV = None
         #default fields used to group components
         self.groups = [
             ColumnList.COL_PART,

--- a/KiBOM_CLI.py
+++ b/KiBOM_CLI.py
@@ -61,6 +61,7 @@ parser.add_argument("-n", "--number", help="Number of boards to build (default =
 parser.add_argument("-v", "--verbose", help="Enable verbose output", action='count')
 parser.add_argument("-r", "--revision", help="Board variant, used to determine which components are output to the BoM", type=str, default=None)
 parser.add_argument("--cfg", help="BoM config file (script will try to use 'bom.ini' if not specified here)")
+parser.add_argument("-s","--separator",help="CSV Separator (default ',')",type=str, default=None)
 
 args = parser.parse_args()
     
@@ -95,6 +96,7 @@ if have_cfile:
 #pass various command-line options through
 pref.verbose = verbose
 pref.boards = args.number
+pref.separatorCSV = args.separator
 
 if args.revision is not None:
     pref.pcbConfig = args.revision

--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ optional arguments:
                         output to the BoM
   --cfg CFG             BoM config file (script will try to use 'bom.ini' if
                         not specified here)
+  -s SEPARATOR, --separator SEPARATOR
+
 ~~~~                        
     
 
@@ -54,6 +56,7 @@ optional arguments:
 
 **--cfg** If provided, this is the BOM config file that will be used. If not provided, options will be loaded from "bom.ini"
 
+**-s --separator** Override the delimiter for CSV or TSV generation
 To run from KiCad, simply add the same command line in the *Bill of Materials* script window. e.g. to generate a HTML output:
 
 ![alt tag](example/html_ex.png?raw=True "HTML Example")


### PR DESCRIPTION
Added -s and --separator options to override the CSV separator (delimiter) with respect to auto detection when nothing specified.

This allow to use `;` delimiter to read the BOM with Excel without replacing the commas. 
It's a quick feature, i would added it to the configuration file, but it looks a bit complicated to me (and i don't have a ton of time)

However, if you think that the feature should appear in the conf file, i can try to look into it...

The script is quite useful btw, nice work 😄 
Best,
Julien