### PR TITLE
Fix PCB configurations feature for "+blah"

### DIFF
--- a/KiBOM/component.py
+++ b/KiBOM/component.py
@@ -222,7 +222,8 @@ class Component():
                 result = False
                 break
             if opt.startswith("+"):
-                if opt.lower() == self.prefs.pcbConfig.lower():
+                result = False
+                if opt[1:].lower() == self.prefs.pcbConfig.lower():
                     result = True
 
         #by default, part is fitted


### PR DESCRIPTION
README.md says:
 "If the fit_field begins with a '+' character, if will ONLY be included in the matching configuration."
so make +foo implement that; it seems to have bitrotted or to never have
been implemented/tested.