### PR TITLE
minor fix

### DIFF
--- a/KiBOM/preferences.py
+++ b/KiBOM/preferences.py
@@ -1,4 +1,4 @@
-
+#!/usr/bin/env python2
 import sys
 
 if sys.version_info.major >= 3:


### PR DESCRIPTION
Arch Linux tries to execute this file as python 3 if other version is not specified, and then fails when user presses "Generate" button.