### PR TITLE
Adding basic support for Travis-CI testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,54 @@
+# travis-ci integration for KiBOM
+
+sudo:
+  - false
+
+os:
+  - linux
+
+language:
+  - python
+
+python:
+  - "2.7"
+  - "3.3"
+  - "3.4"
+  - "3.5"
+  - "3.6"
+  - "3.7-dev"
+  - "nightly"
+
+addons:
+  apt:
+    packages:
+      - tree
+
+# Test Scripts
+env:
+  # Basic Tests
+  - DIR=tests SCRIPT=sanity.bash
+
+# Exclusions
+matrix:
+  allow_failures:
+    - python: "3.7-dev"
+    - python: "nightly"
+
+# System setup
+install:
+  # Info about OS
+  - uname -a
+
+  # Directory tree to validate kll.git
+  - tree
+
+  # Python Version
+  - python --version
+
+# Run test script(s)
+script:
+  - (cd ${DIR} && ./${SCRIPT})
+
+# Post test script commands
+after_script:
+  - tree

--- a/KiBOM_CLI.py
+++ b/KiBOM_CLI.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python
 """
     @package
     KiBOM - Bill of Materials generation for KiCad

--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
 # KiBoM
+
+[![Travis Status](https://travis-ci.org/haata/KiBoM.svg?branch=master)](https://travis-ci.org/haata/KiBoM)
+
 Configurable BoM generation tool for KiCad EDA (http://kicad-pcb.org/)
 
 ## Description

--- a/tests/common.bash
+++ b/tests/common.bash
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# Common functions for running various tests
+
+PASSED=0
+FAILED=0
+
+# Results
+result() {
+	echo "--- Results ---"
+	echo "${PASSED}/$((PASSED+FAILED))"
+	if (( FAILED == 0 )); then
+		return 0
+	else
+		return 1
+	fi
+}
+
+# Runs a command, increments test passed/failed
+# Args: Command
+cmd() {
+	# Run command
+	echo "CMD: $@"
+	$@
+	local RET=$?
+
+	# Check command
+	if [[ ${RET} -ne 0 ]]; then
+		((FAILED++))
+	else
+		((PASSED++))
+	fi
+
+	return ${RET}
+}

--- a/tests/sanity.bash
+++ b/tests/sanity.bash
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# Basic run-time sanity check for KiBoM
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Common functions
+source ${SCRIPT_DIR}/common.bash
+
+# Start in kll top-level directory
+cd ${SCRIPT_DIR}/..
+
+
+## Tests
+
+cmd ./KiBOM_CLI.py --help
+
+## Tests complete
+
+
+result
+exit $?


### PR DESCRIPTION
- Just runs a --help on each version of Python
- 2.7, 3.3, 3.4, 3.5, 3.6
- 3.7-dev, and nightly (which are allowed to fail)

This should make sure changes keep being compatible.
Will need PR #30 in order to pass the tests (Python 2.7 does pass though): https://travis-ci.org/haata/KiBoM/builds/378204678 vs. https://travis-ci.org/haata/KiBoM/builds/378203999

The README.md link will have to change once Travis-CI is setup on your end.