### PR TITLE
Use new description attribute in libsource for aliases

### DIFF
--- a/bomlib/component.py
+++ b/bomlib/component.py
@@ -123,6 +123,9 @@ class Component():
     def getLibName(self):
         return self.element.get("libsource", "lib")
 
+    def getDescription(self):
+        return self.element.get("libsource", "description")
+
     def setValue(self, value):
         """Set the value of this component"""
         v = self.element.getChild("value")
@@ -305,12 +308,6 @@ class Component():
 
     def getTimestamp(self):
         return self.element.get("tstamp")
-
-    def getDescription(self, libraryToo=True):
-        ret = self.element.get("field", "name", "Description")
-        if ret =="" and libraryToo:
-            ret = self.libpart.getDescription()
-        return ret
 
 class joiner:
     def __init__(self):

--- a/bomlib/netlist_reader.py
+++ b/bomlib/netlist_reader.py
@@ -213,9 +213,6 @@ class libpart():
     def getPartName(self):
         return self.element.get("libpart", "part")
 
-    def getDescription(self):
-        return self.element.get("description")
-
     def getDocs(self):
         return self.element.get("docs")
 


### PR DESCRIPTION
I filed [a bug in KiCad](https://bugs.launchpad.net/kicad/+bug/1774358) about the description field in  the netlist generator script being incorrect when the component is an alias. [It has now been fixed](https://github.com/KiCad/kicad-source-mirror/commit/e0c881b63923d62ee95e947501fd6bb30d951644) in the latest nightly by adding a `description` attribute to the `libsource` element, but it looks like KiBoM needs to know about it.