### PR TITLE
Add Farnell pricing integration

### DIFF
--- a/bomlib/preferences.py
+++ b/bomlib/preferences.py
@@ -56,7 +56,15 @@ class BomPref:
 
         self.separatorCSV = None
         self.includeVersionNumber = True
-
+        self.farnell = {
+            "enabled" : False,
+            "api" : None,
+            "store_id" : "uk",
+            "column" : "Farnell SKU",
+            "api_per_sec" : 2,
+            "decimal_separator" : "."
+            }
+        
         # Default fields used to group components
         self.groups = [
             ColumnList.COL_PART,

--- a/partpycker/farnell.py
+++ b/partpycker/farnell.py
@@ -1,0 +1,170 @@
+
+from __future__ import print_function
+import urllib2
+import time
+import json
+
+from collections import defaultdict
+class Query :
+	def __init__(self,term,store_id,api_key,signature=None,timestamp=None,customer_id=None,offset=0,number_of_results=25,rohs=None,in_stock=None,response_group="small",format="XML",strip_xml_namespace=False,json_callback=None):
+		"""
+
+		:param str term:
+		:param str store_id:
+		:param str api_key:
+		:param signature:
+		:param timestamp:
+		:param customer_id:
+		:param offset:
+		:param number_of_results:
+		:param rohs:
+		:param in_stock:
+		:param response_group:
+		:param format:
+		:param strip_xml_namespace:
+		:param json_callback:
+		"""
+		self.json_callback = json_callback
+		self.strip_xml_namespace = strip_xml_namespace
+		self.format = format.upper()
+		self.response_group = response_group
+		self.in_stock = in_stock
+		self.rohs = rohs
+		self.number_of_results = number_of_results
+		self.offset = offset
+		self.term = term
+		self.store = store_id
+		self.api = api_key
+		self.signature = signature
+		self.timestamp = timestamp
+		self.customer_id = customer_id
+		
+	def __str__(self):
+		out =""
+		if self.format not in ["XML","JSON"] :
+			raise ValueError("{} format invalid. Format must be JSON or XML".format(self.format))
+		xml = self.format == "XML"
+		
+		if not xml :
+			out += "callInfo.responseDataFormat=JSON&"
+			if self.json_callback is not None :
+				out += "callInfo.callback={}&".format(self.json_callback)
+		else :
+			if self.strip_xml_namespace :
+				out += "callInfo.omitXmlSchema=true&"
+		
+		
+		previous = 0
+		keyword= False
+		for i in range(0,self.term.count(":")) :
+			prev_ini = previous
+			for key in ["any","id","manuPartNum"] :
+				if self.term.find(":",previous) == self.term.find(key,previous) +len(key) :
+					previous = self.term.find(":",previous) +1
+					if key == "any" :
+						keyword = True
+					break
+			if previous == prev_ini :
+				raise ValueError("Invalid term {}".format(self.term))
+		out += "term={}&".format(self.term)
+		out += "storeInfo.id={}&".format(self.store)
+		out += "callInfo.apiKey={}&".format(self.api)
+		
+		if self.signature is not None and self.timestamp is not None and self.customer_id is not None :
+			out+="userInfo.signature={}&userInfo.timestamp={}&userInfo.customerId={}&".format(self.signature,self.timestamp,self.customer_id)
+		
+		if keyword :
+			out+="resultsSettings.offset={}&resultsSettings.numberOfResults={}&".format(self.offset,self.number_of_results)
+		
+		if self.rohs or self.in_stock :
+			refine = (("rohsCompliant," if self.rohs else "")+("inStock" if self.in_stock else ""))[:-1]
+			out+="resultsSettings.refinements.filters={}&".format(refine)
+		if self.response_group != "small" :
+			out+="resultsSettings.responseGroup="+self.response_group
+		
+		return out
+		
+class Farnell:
+	#Base HTTP address for API calls. Can be accessed from anywhere.
+	base_address = "https://api.element14.com/catalog/products?"
+	
+	def __init__(self,api_key, store_id = "uk", api_call_per_second = 2):
+		"""
+
+		:param str api_key: Retrieved by going to https://partner.element14.com
+		:param str store_id: Id of the store to look in. May be the full address
+							(uk.farnell.com) or only the prefix if the end is
+							.farnell.com
+		:param int api_call_per_second: Maximum API calls per second
+		"""
+		
+		self.api_key  = api_key
+		self.store_id = store_id + (".farnell.com" if "." not in store_id else "")
+		self.api_cooldown = 1.0/api_call_per_second
+		self.last_call_time = 0.0
+		
+	def wait_api_cooldown(self):
+		"""
+		Wait for API to be available again
+		"""
+		delta = time.clock() - self.last_call_time
+		if delta < self.api_cooldown :
+			time.sleep(self.api_cooldown - delta)
+	
+	
+	
+	def _request_send(self,req):
+		"""
+		Low level function to send api call (set the timer)
+		
+		:param str req: End of the URL to send
+		"""
+		self.wait_api_cooldown()
+		ret = urllib2.urlopen(Farnell.base_address + str(req)).read()
+		self.last_call_time = time.clock()
+		return ret
+	
+	def retrieve_price(self,parts):
+		"""
+
+		:param  dict parts:
+		:rtype: object
+		"""
+	
+		query_search = "id:" + "%20".join([str(x) for x in parts.keys()])
+		q = Query(query_search,self.store_id,self.api_key,response_group="prices",format="JSON")
+		result = json.loads(self._request_send(q))
+		
+		output = defaultdict(dict)
+		
+		
+		for product in result["premierFarnellPartNumberReturn"]["products"] :
+			prod_id = product["sku"]
+			min_order = int(product["translatedMinimumOrderQuality"])
+			
+			
+			#output[prod_id]["order_qty"]
+			order_qty = parts[prod_id] + (min_order - parts[prod_id] % min_order)
+			order_price = None
+			for price in product["prices"] :
+				if int(price["from"]) <= order_qty <= int(price["to"]) :
+					order_price = float(price["cost"])
+					break
+					
+			output[prod_id]["order_qty"] = order_qty
+			output[prod_id]["unit_price"] = order_price
+		
+		return output
+			
+			
+			
+		
+		
+if __name__ == "__main__" :
+	print("Query Test")
+	t = Query("id:80056","fr.farnell.com","monApi")
+	print("Simple\t",t)
+	
+	db = Farnell("API_Number","fr")
+
+	print(db.retrieve_price({"2725932":2,"8648689":2}))

--- a/partpycker/farnell.py
+++ b/partpycker/farnell.py
@@ -1,8 +1,8 @@
 
 from __future__ import print_function
-import urllib2
+
+import requests
 import time
-import json
 
 from collections import defaultdict
 class Query :
@@ -120,7 +120,8 @@ class Farnell:
 		:param str req: End of the URL to send
 		"""
 		self.wait_api_cooldown()
-		ret = urllib2.urlopen(Farnell.base_address + str(req)).read()
+		
+		ret = requests.get(Farnell.base_address + str(req)).json()
 		self.last_call_time = time.clock()
 		return ret
 	
@@ -133,7 +134,7 @@ class Farnell:
 	
 		query_search = "id:" + "%20".join([str(x) for x in parts.keys()])
 		q = Query(query_search,self.store_id,self.api_key,response_group="prices",format="JSON")
-		result = json.loads(self._request_send(q))
+		result = self._request_send(q)
 		
 		output = defaultdict(dict)
 		

--- a/partpycker/farnell.py
+++ b/partpycker/farnell.py
@@ -1,8 +1,11 @@
 
 from __future__ import print_function
 
-import requests
+import sys
+import urllib
+	
 import time
+import json
 
 from collections import defaultdict
 class Query :
@@ -119,9 +122,12 @@ class Farnell:
 		
 		:param str req: End of the URL to send
 		"""
-		self.wait_api_cooldown()
 		
-		ret = requests.get(Farnell.base_address + str(req)).json()
+		self.wait_api_cooldown()
+		if sys.version_info < (3,) :
+			ret = urllib.urlopen(Farnell.base_address + str(req)).read()
+		else :
+			ret = urllib.request.urlopen(Farnell.base_address + str(req)).read()
 		self.last_call_time = time.clock()
 		return ret
 	
@@ -134,7 +140,7 @@ class Farnell:
 	
 		query_search = "id:" + "%20".join([str(x) for x in parts.keys()])
 		q = Query(query_search,self.store_id,self.api_key,response_group="prices",format="JSON")
-		result = self._request_send(q)
+		result = json.loads(self._request_send(q))
 		
 		output = defaultdict(dict)
 		


### PR DESCRIPTION
Hi,

I just made a small module (partpycker) which use the Farnell API to retrieve parts from a Farnell SKU (part number).

I integrated it with your BOM tool that I use.
Could you have a look at it ?

Please note that I integrated that rather roughly so, there is *for sure* some work to do on cleaning the way I integrated my system.

To use this system, you will have to retrieve a (free) API key from Farnell (https://partner.element14.com/page). If you don't have an account, don't wanna bother and want to gives it a quick shot, I might share my key with you but I don't want it to be put in the final script.

To use the script, you may : 
1. Add a dedicated field to all relevant part (Default name : Farnell SKU but you may call it as you want)
2. Fill it with the relevant ordering number (SKU) from farnell (2725994 for an IRFZ34N Mosfet as example)
3. Edit the command line of the script. Mine looks like  `python "/home/julien/Projets/Tools/KiBoM/KiBOM_CLI.py" -s ";" "%I" "%O" --farnell YourAPIkey "Farnell SKU" fr ','`.
The `fr` is to get the prices from the french website. You may use any value from https://partner.element14.com/docs/Product_Search_API_REST__Description#storeinfo and omit ".farnell.com" if relevant. The `','` is to get a comma as decimal separator (curses to Excel and open office...). If your system uses a dot, you may omit this parameter.
4. Enjoy !

I will (probably :innocent: ) open a github repository for partpycker later...

Thanks for any feedback,
Regards,
Julien FAUCHER