### PR TITLE
Fix for how config works

### DIFF
--- a/bomlib/component.py
+++ b/bomlib/component.py
@@ -236,17 +236,21 @@ class Component():
 
         opts = check.split(",")
 
-        result = True
 
+        included = not bool(opts) #included by default if no options
+        excluded = False
+
+        config = self.prefs.pcbConfig.lower()
         for opt in opts:
             #options that start with '-' are explicitly removed from certain configurations
-            if opt.startswith('-') and opt[1:].lower() == self.prefs.pcbConfig.lower():
-                result = False
+            if opt.startswith('-') and opt[1:].lower() == config:
+                excluded = True
                 break
-            if opt.startswith("+"):
-                result = False
-                if opt[1:].lower() == self.prefs.pcbConfig.lower():
-                    result = True
+            if opt.startswith("+") and opt[1:].lower() == config:
+                included = True
+                break
+
+        result = included and not excluded
 
         #by default, part is fitted
         return result


### PR DESCRIPTION
Consider a `Config` field for a component is `-bat_pwr,+ext_pwr,+dual_pwr,+kitchen_sink`

Let's ignore the exclude (bat_pwr). This component is present in multiple variants; ext_pwr, dual_pwr, kitchen_sink

Given the current code below, and assuming we selected ext_pwr:

```python
    result = True
    for opt in opts:
        #options that start with '-' are explicitly removed from certain configurations
        if opt.startswith('-') and opt[1:].lower() == self.prefs.pcbConfig.lower():
            result = False
            break
        if opt.startswith("+"):
            result = False
            if opt[1:].lower() == self.prefs.pcbConfig.lower():
                result = True
```

This means that the result will be `False` for this component because it loops through opts multiple times.  The _last_ opt is +kitchen_sink, but since it sets result to `False`, and the following `if` statement fails (because we're using ext_pwr), this component is not fitted.

Proposed change: 

```python

included = not bool(opts) #included by default if no options
excluded = False

config = self.prefs.pcbConfig.lower()
for opt in opts:
    #options that start with '-' are explicitly removed from certain configurations
    if opt.startswith('-') and opt[1:].lower() == config:
        excluded = True
        break
    if opt.startswith("+") and opt[1:].lower() == config:
        included = True
        break

result = included and not excluded
```

* `included` is set to `True` if opts is empty, else it's `False`
* Any hit on the iterate breaks, since `pcbConfig` is only a single value
* Edge cases where a config includes the same variant twice, then the _first_ variant that matches will take precedence.  Arguably, this should be an error condition.

