### PR TITLE
Add optional `bom.ini` configuration of `boards` (qty of PCBs in the BOM) and `pcbConfig` (the PCB variant).

### DIFF
--- a/KiBOM_CLI.py
+++ b/KiBOM_CLI.py
@@ -58,7 +58,7 @@ parser = argparse.ArgumentParser(description="KiBOM Bill of Materials generator 
 
 parser.add_argument("netlist", help='xml netlist file. Use "%%I" when running from within KiCad')
 parser.add_argument("output",  default="", help='BoM output file name.\nUse "%%O" when running from within KiCad to use the default output name (csv file).\nFor e.g. HTML output, use "%%O.html"')
-parser.add_argument("-n", "--number", help="Number of boards to build (default = 1)", type=int, default=1)
+parser.add_argument("-n", "--number", help="Number of boards to build (default = 1)", type=int, default=None)
 parser.add_argument("-v", "--verbose", help="Enable verbose output", action='count')
 parser.add_argument("-r", "--variant", help="Board variant, used to determine which components are output to the BoM", type=str, default=None)
 parser.add_argument("--cfg", help="BoM config file (script will try to use 'bom.ini' if not specified here)")
@@ -96,12 +96,14 @@ if have_cfile:
 
 #pass various command-line options through
 pref.verbose = verbose
-pref.boards = args.number
+if args.number is not None:
+    pref.boards = args.number
 pref.separatorCSV = args.separator
 
 if args.variant is not None:
     pref.pcbConfig = args.variant
-    print("PCB variant:", args.variant)
+print("PCB variant:", pref.pcbConfig)
+
 
 #write preference file back out (first run will generate a file with default preferences)
 if not have_cfile:

--- a/bomlib/preferences.py
+++ b/bomlib/preferences.py
@@ -28,6 +28,8 @@ class BomPref:
     OPT_IGNORE_DNF = "ignore_dnf"
     OPT_BACKUP = "make_backup"
     OPT_INCLUDE_VERSION = "include_version_number"
+    OPT_DEFAULT_BOARDS = "number_boards"
+    OPT_DEFAULT_PCBCONFIG = "board_variant"
 
     OPT_CONFIG_FIELD = "fit_field"
 
@@ -45,7 +47,7 @@ class BomPref:
         self.groupConnectors = True  # Group connectors and ignore component value
         self.useRegex = True  # Test various columns with regex
 
-        self.boards = 1
+        self.boards = 1 # Quantity of boards to be made
         self.mergeBlankFields = True  # Blanks fields will be merged when possible
         self.hideHeaders = False
         self.verbose = False  # By default, is not verbose
@@ -130,6 +132,12 @@ class BomPref:
             if cf.has_option(self.SECTION_GENERAL, self.OPT_CONFIG_FIELD):
                 self.configField = cf.get(self.SECTION_GENERAL, self.OPT_CONFIG_FIELD)
 
+            if cf.has_option(self.SECTION_GENERAL, self.OPT_DEFAULT_BOARDS):
+                self.boards = self.checkInt(cf, self.OPT_DEFAULT_BOARDS, default=None)
+
+            if cf.has_option(self.SECTION_GENERAL, self.OPT_DEFAULT_PCBCONFIG):
+                self.pcbConfig = cf.get(self.SECTION_GENERAL, self.OPT_DEFAULT_PCBCONFIG)
+
             if cf.has_option(self.SECTION_GENERAL, self.OPT_BACKUP):
                 self.backup = cf.get(self.SECTION_GENERAL, self.OPT_BACKUP)
             else:
@@ -194,6 +202,12 @@ class BomPref:
 
         cf.set(self.SECTION_GENERAL, '; Make a backup of the bom before generating the new one, using the following template')
         cf.set(self.SECTION_GENERAL, self.OPT_BACKUP, self.backup)
+        
+        cf.set(self.SECTION_GENERAL, '; Default number of boards to produce if none given on CLI with -n')
+        cf.set(self.SECTION_GENERAL, self.OPT_DEFAULT_BOARDS, self.boards)
+
+        cf.set(self.SECTION_GENERAL, '; Default PCB variant if none given on CLI with -r')
+        cf.set(self.SECTION_GENERAL, self.OPT_DEFAULT_PCBCONFIG, self.pcbConfig)
 
         cf.add_section(self.SECTION_IGNORE)
         cf.set(self.SECTION_IGNORE, "; Any column heading that appears here will be excluded from the Generated BoM")


### PR DESCRIPTION
Bom.ini values are used if the command line arguments are *not* provided.

This allows project defaults to be set as generally the `pcbConfig` options will be project specific, but KiCAD persists the command line options between projects requiring manual entry of these each time you switch project.

This is also helpful for projects where version control is used as the variant and number will persist in `bom.ini` if it is in git/whatever vcs.