### PR TITLE
Internationalization - support for headings/titles/labels translation

### DIFF
--- a/KiBOM_CLI.py
+++ b/KiBOM_CLI.py
@@ -63,6 +63,7 @@ parser.add_argument("-v", "--verbose", help="Enable verbose output", action='cou
 parser.add_argument("-r", "--variant", help="Board variant, used to determine which components are output to the BoM", type=str, default=None)
 parser.add_argument("--cfg", help="BoM config file (script will try to use 'bom.ini' if not specified here)")
 parser.add_argument("-s","--separator",help="CSV Separator (default ',')",type=str, default=None)
+parser.add_argument("-l", "--language", help="Language of labels and headings (default 'en')", type=str, default=None)
 
 args = parser.parse_args()
 
@@ -104,6 +105,8 @@ if args.variant is not None:
     pref.pcbConfig = args.variant
 print("PCB variant:", pref.pcbConfig)
 
+if args.language is not None:
+    pref.language = args.language
 
 #write preference file back out (first run will generate a file with default preferences)
 if not have_cfile:

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ The *KiBOM_CLI* script can be run directly from KiCad or from the command line. 
 
 ~~~~
 usage: KiBOM_CLI.py [-h] [-n NUMBER] [-v] [-r VARIANT] [--cfg CFG]
-                    [-s SEPARATOR]
+                    [-s SEPARATOR] [-l LANGUAGE]
                     netlist output
 
 KiBOM Bill of Materials generator script
@@ -44,6 +44,9 @@ optional arguments:
                         not specified here)
   -s SEPARATOR, --separator SEPARATOR
                         CSV Separator (default ',')
+  -l LANGUAGE, --language LANGUAGE
+                        Language of labels and headings (default 'en')
+
 
 
 ~~~~                        
@@ -66,6 +69,8 @@ optional arguments:
 **--cfg** If provided, this is the BOM config file that will be used. If not provided, options will be loaded from "bom.ini"
 
 **-s --separator** Override the delimiter for CSV or TSV generation
+
+**-l --language** Default language for labels, titles and headings is english.
 
 --------
 To run from KiCad, simply add the same command line in the *Bill of Materials* script window. e.g. to generate a HTML output:
@@ -183,6 +188,9 @@ Multiple BoM output formats are supported:
 * HTML
 
 Output file format selection is set by the output filename. e.g. "bom.html" will be written to a HTML file, "bom.csv" will be written to a CSV file.
+
+### Languages
+Language defitions are located in 'languages' folder as YAML files. You can provide Your own file for specific language. Just copy 'en.yaml' file, change its name to 'your-language-short-code.yaml', then translate values. Don't change keys!
 
 ### Configuration File
 BoM generation options can be configured (on a per-project basis) by editing the *bom.ini* file in the PCB project directory. This file is generated the first time that the KiBoM script is run, and allows configuration of the following options.

--- a/bomlib/csv_writer.py
+++ b/bomlib/csv_writer.py
@@ -1,10 +1,10 @@
-# _*_ coding:latin-1 _*_
 
 import csv
 import bomlib.columns as columns
 from bomlib.component import *
 import os, shutil
 from bomlib.preferences import BomPref
+from bomlib.i18n import *
 
 """
 Write BoM out to a CSV file
@@ -36,15 +36,23 @@ def WriteCSV(filename, groups, net, headings, prefs):
     nFitted = sum([g.getCount() for g in groups if g.isFitted()])
     nBuild = nFitted * prefs.boards
 
+    msg,coltitle = LangLoadStr(prefs)
+
     with open(filename, "w") as f:
 
         writer = csv.writer(f, delimiter=delimiter, lineterminator="\n")
 
         if not prefs.hideHeaders:
+            modHeadings = []
+            for i,h in enumerate(headings):
+                if (h in ColumnList._COLUMNS_GEN) or (h in ColumnList._COLUMNS_PROTECTED):
+                    modHeadings.append(coltitle[h])
+                else:
+                    modHeadings.append(h)
             if prefs.numberRows:
-                writer.writerow(["Component"] + headings)
+                writer.writerow([msg["COMPONENT"]] + modHeadings)
             else:
-                writer.writerow(headings)
+                writer.writerow(modHeadings)
 
         count = 0
         rowCount = 1
@@ -57,8 +65,6 @@ def WriteCSV(filename, groups, net, headings, prefs):
             if prefs.numberRows:
                 row = [str(rowCount)] + row
 
-            #deal with unicode characters
-            #row = [el.decode('latin-1') for el in row]
             writer.writerow(row)
 
             try:
@@ -73,15 +79,15 @@ def WriteCSV(filename, groups, net, headings, prefs):
             for i in range(5):
                 writer.writerow([])
 
-            writer.writerow(["Component Groups:",nGroups])
-            writer.writerow(["Component Count:",nTotal])
-            writer.writerow(["Fitted Components:", nFitted])
-            writer.writerow(["Number of PCBs:",prefs.boards])
-            writer.writerow(["Total components:", nBuild])
-            writer.writerow(["Schematic Version:",net.getVersion()])
-            writer.writerow(["Schematic Date:",net.getSheetDate()])
-            writer.writerow(["BoM Date:",net.getDate()])
-            writer.writerow(["Schematic Source:",net.getSource()])
-            writer.writerow(["KiCad Version:",net.getTool()])
+            writer.writerow([msg["COMPONENT_GROUPS"]+":",nGroups])
+            writer.writerow([msg["COMPONENT_COUNT_PER_PCB"]+":",nTotal])
+            writer.writerow([msg["FITTED_COMPONENTS_PER_PCB"]+":", nFitted])
+            writer.writerow([msg["NUMBER_OF_PCBS"]+":",prefs.boards])
+            writer.writerow([msg["TOTAL_COMPONENT_COUNT"]+":", nBuild])
+            writer.writerow([msg["SCHEMATIC_VERSION"]+":",net.getVersion()])
+            writer.writerow([msg["SCHEMATIC_DATE"]+":",net.getSheetDate()])
+            writer.writerow([msg["BOM_DATE"]+":",net.getDate()])
+            writer.writerow([msg["SOURCE_FILE"]+":",net.getSource()])
+            writer.writerow([msg["KICAD_VERSION"]+":",net.getTool()])
 
     return True

--- a/bomlib/html_writer.py
+++ b/bomlib/html_writer.py
@@ -2,6 +2,7 @@
 import bomlib.columns as columns
 from bomlib.component import *
 import os
+from bomlib.i18n import *
 
 BG_GEN = "#E6FFEE"
 BG_KICAD = "#FFE6B3"
@@ -47,6 +48,8 @@ def WriteHTML(filename, groups, net, headings, prefs):
     nTotal = sum([g.getCount() for g in groups])
     nFitted = sum([g.getCount() for g in groups if g.isFitted()])
     nBuild = nFitted * prefs.boards
+ 
+    msg,coltitle = LangLoadStr(prefs)
 
     with open(filename,"w") as html:
 
@@ -60,25 +63,25 @@ def WriteHTML(filename, groups, net, headings, prefs):
 
         #PCB info
         if not prefs.hideHeaders:
-            html.write("<h2>KiBoM PCB Bill of Materials</h2>\n")
+            html.write("<h2>{m}</h2>\n".format(m=msg["KIBOM_PCB_BILL_OF_MATERIALS"]))
             html.write('<table border="1">\n')
-            html.write("<tr><td>Source File</td><td>{source}</td></tr>\n".format(source=net.getSource()))
-            html.write("<tr><td>BoM Date</td><td>{date}</td></tr>\n".format(date=net.getDate()))
-            html.write("<tr><td>Schematic Version</td><td>{version}</td></tr>\n".format(version=net.getVersion()))
-            html.write("<tr><td>Schematic Date</td><td>{date}</td></tr>\n".format(date=net.getSheetDate()))
-            html.write("<tr><td>KiCad Version</td><td>{version}</td></tr>\n".format(version=net.getTool()))
-            html.write("<tr><td>Component Groups</td><td>{n}</td></tr>\n".format(n=nGroups))
-            html.write("<tr><td>Component Count (per PCB)</td><td>{n}</td></tr>\n".format(n=nTotal))
-            html.write("<tr><td>Fitted Components (per PCB)</td><td>{n}</td></tr>\n".format(n=nFitted))
-            html.write("<tr><td>Number of PCBs</td><td>{n}</td></tr>\n".format(n=prefs.boards))
-            html.write("<tr><td>Total Component Count<br>(for {n} PCBs)</td><td>{t}</td></tr>\n".format(n=prefs.boards, t=nBuild))
+            html.write("<tr><td>{m}</td><td>{source}</td></tr>\n".format(m=msg["SOURCE_FILE"],source=net.getSource()))
+            html.write("<tr><td>{m}</td><td>{date}</td></tr>\n".format(m=msg["BOM_DATE"],date=net.getDate()))
+            html.write("<tr><td>{m}</td><td>{version}</td></tr>\n".format(m=msg["SCHEMATIC_VERSION"],version=net.getVersion()))
+            html.write("<tr><td>{m}</td><td>{date}</td></tr>\n".format(m=msg["SCHEMATIC_DATE"],date=net.getSheetDate()))
+            html.write("<tr><td>{m}</td><td>{version}</td></tr>\n".format(m=msg["KICAD_VERSION"],version=net.getTool()))
+            html.write("<tr><td>{m}</td><td>{n}</td></tr>\n".format(m=msg["COMPONENT_GROUPS"],n=nGroups))
+            html.write("<tr><td>{m}</td><td>{n}</td></tr>\n".format(m=msg["COMPONENT_COUNT_PER_PCB"],n=nTotal))
+            html.write("<tr><td>{m}</td><td>{n}</td></tr>\n".format(m=msg["FITTED_COMPONENTS_PER_PCB"],n=nFitted))
+            html.write("<tr><td>{m}</td><td>{n}</td></tr>\n".format(m=msg["NUMBER_OF_PCBS"],n=prefs.boards))
+            html.write("<tr><td>{m1}<br>({m2} {n} {m3})</td><td>{t}</td></tr>\n".format(m1=msg["TOTAL_COMPONENT_COUNT"],m2=msg["FOR"],m3=msg["PCBS"],n=prefs.boards, t=nBuild))
             html.write("</table>\n")
             html.write("<br>\n")
-            html.write("<h2>Component Groups</h2>\n")
-            html.write('<p style="background-color: {bg}">KiCad Fields (default)</p>\n'.format(bg=BG_KICAD))
-            html.write('<p style="background-color: {bg}">Generated Fields</p>\n'.format(bg=BG_GEN))
-            html.write('<p style="background-color: {bg}">User Fields</p>\n'.format(bg=BG_USER))
-            html.write('<p style="background-color: {bg}">Empty Fields</p>\n'.format(bg=BG_EMPTY))
+            html.write("<h2>{m}</h2>\n".format(m=msg["COMPONENT_GROUPS"]))
+            html.write('<p style="background-color: {bg}">{m}</p>\n'.format(m=msg["KICAD_FIELDS_DEFAULT"],bg=BG_KICAD))
+            html.write('<p style="background-color: {bg}">{m}</p>\n'.format(m=msg["GENERATED_FIELDS"],bg=BG_GEN))
+            html.write('<p style="background-color: {bg}">{m}</p>\n'.format(m=msg["USER_FIELDS"],bg=BG_USER))
+            html.write('<p style="background-color: {bg}">{m}</p>\n'.format(m=msg["EMPTY_FIELDS"],bg=BG_EMPTY))
 
         #component groups
         html.write('<table border="1">\n')
@@ -90,6 +93,8 @@ def WriteHTML(filename, groups, net, headings, prefs):
         for i,h in enumerate(headings):
             #cell background color
             bg = bgColor(h)
+            if (h in ColumnList._COLUMNS_GEN) or (h in ColumnList._COLUMNS_PROTECTED):
+                h = coltitle[h]
             html.write('\t<th align="center"{bg}>{h}</th>\n'.format(
                         h=h,
                         bg = ' bgcolor="{c}"'.format(c=bg) if bg else ''))

--- a/bomlib/i18n.py
+++ b/bomlib/i18n.py
@@ -1,0 +1,16 @@
+
+import os
+import yaml    
+
+def LangLoadStr(prefs):
+    
+    script_dir = os.path.dirname(__file__)
+    lang_filename = os.path.join(script_dir, "../languages/"+prefs.language+".yaml")
+    messsages = {}
+    
+    with open(lang_filename,"r") as lang_file:
+        elements = yaml.load(lang_file)
+        messages = {k: unicode(v).encode("utf-8") for k,v in elements["_MESSAGES"].iteritems()}
+        columns = {k: unicode(v).encode("utf-8") for k,v in elements["_COLUMNS"].iteritems()}
+        
+    return (messages,columns)

--- a/bomlib/preferences.py
+++ b/bomlib/preferences.py
@@ -32,6 +32,7 @@ class BomPref:
     OPT_DEFAULT_PCBCONFIG = "board_variant"
 
     OPT_CONFIG_FIELD = "fit_field"
+    OPT_LANGUAGE = "language"
 
     def __init__(self):
         # List of headings to ignore in BoM generation
@@ -53,6 +54,8 @@ class BomPref:
         self.verbose = False  # By default, is not verbose
         self.configField = "Config"  # Default field used for part fitting config
         self.pcbConfig = "default"
+
+        self.language = "en"
 
         self.backup = "%O.tmp"
 
@@ -142,6 +145,9 @@ class BomPref:
                 self.backup = cf.get(self.SECTION_GENERAL, self.OPT_BACKUP)
             else:
                 self.backup = False
+                
+            if cf.has_option(self.SECTION_GENERAL, self.OPT_LANGUAGE):
+                self.language = cf.get(self.SECTION_GENERAL, self.OPT_LANGUAGE)
 
             # Read out grouping colums
             if self.SECTION_GROUPING_FIELDS in cf.sections():
@@ -208,6 +214,9 @@ class BomPref:
 
         cf.set(self.SECTION_GENERAL, '; Default PCB variant if none given on CLI with -r')
         cf.set(self.SECTION_GENERAL, self.OPT_DEFAULT_PCBCONFIG, self.pcbConfig)
+        
+        cf.set(self.SECTION_GENERAL, '; Titles and headings language if non given on CLI with -l')
+        cf.set(self.SECTION_GENERAL, self.OPT_LANGUAGE, self.language)
 
         cf.add_section(self.SECTION_IGNORE)
         cf.set(self.SECTION_IGNORE, "; Any column heading that appears here will be excluded from the Generated BoM")

--- a/bomlib/xml_writer.py
+++ b/bomlib/xml_writer.py
@@ -3,6 +3,7 @@ from bomlib.component import *
 from xml.etree import ElementTree
 from xml.dom import minidom
 from bomlib.preferences import BomPref
+from bomlib.i18n import *
 
 """
 Write BoM out to an XML file
@@ -22,20 +23,31 @@ def WriteXML(filename, groups, net, headings, prefs):
     nTotal = sum([g.getCount() for g in groups])
     nFitted = sum([g.getCount() for g in groups if g.isFitted()])
     nBuild = nFitted * prefs.boards
+    
+    msg,coltitle = LangLoadStr(prefs)
+
+    for key in msg:
+        msg[key] = msg[key].replace(' ','_') #replace spaces, xml no likey
+        msg[key] = msg[key].replace('"','')
+        msg[key] = msg[key].replace("'",'')
+        msg[key] = msg[key].replace("/",'_')
+        msg[key] = msg[key].replace("(",'')
+        msg[key] = msg[key].replace(")",'')
+        msg[key] = msg[key].decode('utf-8')
 
     attrib = {}
 
-    attrib['Schematic_Source'] = net.getSource()
-    attrib['Schematic_Version'] = net.getVersion()
-    attrib['Schematic_Date'] = net.getSheetDate()
-    attrib['BOM_Date'] = net.getDate()
-    attrib['KiCad_Version'] = net.getTool()
-    attrib['Component_Groups'] = str(nGroups)
-    attrib['Component_Count'] = str(nTotal)
-    attrib['Fitted_Components'] = str(nFitted)
+    attrib[msg["SOURCE_FILE"]] = net.getSource()
+    attrib[msg["SCHEMATIC_VERSION"]] = net.getVersion()
+    attrib[msg["SCHEMATIC_DATE"]] = net.getSheetDate()
+    attrib[msg["BOM_DATE"]] = net.getDate()
+    attrib[msg["KICAD_VERSION"]] = net.getTool()
+    attrib[msg["COMPONENT_GROUPS"]] = str(nGroups)
+    attrib[msg["COMPONENT_COUNT_PER_PCB"]] = str(nTotal)
+    attrib[msg["FITTED_COMPONENTS_PER_PCB"]] = str(nFitted)
 
-    attrib['Number_of_PCBs'] = str(prefs.boards)
-    attrib['Total_Components'] = str(nBuild)
+    attrib[msg["NUMBER_OF_PCBS"]] = str(prefs.boards)
+    attrib[msg["TOTAL_COMPONENT_COUNT"]] = str(nBuild)
 
     xml = ElementTree.Element('KiCad_BOM', attrib = attrib, encoding='utf-8')
 
@@ -48,16 +60,25 @@ def WriteXML(filename, groups, net, headings, prefs):
         attrib = {}
 
         for i,h in enumerate(headings):
+            if (h in ColumnList._COLUMNS_GEN) or (h in ColumnList._COLUMNS_PROTECTED):
+                h = coltitle[h]
             h = h.replace(' ','_') #replace spaces, xml no likey
             h = h.replace('"','')
             h = h.replace("'",'')
+            h = h.replace("/",'_')
+            h = h.replace("(",'')
+            h = h.replace(")",'')
+            h = h.decode('utf-8')
 
-            attrib[h] = str(row[i]).decode('ascii',errors='ignore')
+            attrib[h] = str(row[i]).decode('utf-8',errors='ignore')
 
         sub = ElementTree.SubElement(xml, "group", attrib=attrib)
 
     with open(filename,"w") as output:
         out = ElementTree.tostring(xml, encoding="utf-8")
-        output.write(minidom.parseString(out).toprettyxml(indent="\t"))
+        unistr = minidom.parseString(out).toprettyxml(indent="\t").replace(u'<?xml version="1.0" ?>',
+                          u'<?xml version="1.0" encoding="utf-8"?>')
+        out = unistr.encode('utf-8', 'xmlcharrefreplace')
+        output.write(out)
 
     return True

--- a/languages/en.yaml
+++ b/languages/en.yaml
@@ -1,0 +1,32 @@
+_MESSAGES:
+    KIBOM_PCB_BILL_OF_MATERIALS : KiBoM PCB Bill of Materials
+    SOURCE_FILE : Source file
+    BOM_DATE : BoM Date
+    SCHEMATIC_VERSION : Schematic Version
+    SCHEMATIC_DATE : Schematic Date
+    KICAD_VERSION : KiCad Version
+    COMPONENT : Component
+    COMPONENT_GROUPS : Component Groups
+    COMPONENT_COUNT_PER_PCB : Component Count (per PCB)
+    FITTED_COMPONENTS_PER_PCB : Fitted Components (per PCB)
+    NUMBER_OF_PCBS : Number of PCBs
+    TOTAL_COMPONENT_COUNT : Total Component Count
+    FOR : for
+    PCBS : PCBs
+    KICAD_FIELDS_DEFAULT : KiCad Fields (default)
+    GENERATED_FIELDS : Generated Fields
+    USER_FIELDS : User Fields
+    EMPTY_FIELDS : Empty Fields
+
+_COLUMNS:
+    References : References
+    Description : Description
+    Value : Value
+    Footprint : Footprint
+    Footprint Lib : Footprint Library
+    Part : Part
+    Part Lib : Part Library
+    Datasheet : Datasheet
+    Quantity Per PCB : Quantity Per PCB
+    Total Cost : Total Cost
+    Build Quantity : Build Quantity

--- a/languages/pl.yaml
+++ b/languages/pl.yaml
@@ -1,0 +1,32 @@
+_MESSAGES:
+    KIBOM_PCB_BILL_OF_MATERIALS : KiBoM Zestawienie materiałów PCB
+    SOURCE_FILE : Plik źródłowy
+    BOM_DATE : Data utworzenia BOM
+    SCHEMATIC_VERSION : Wersja schematu
+    SCHEMATIC_DATE : Data utworzenia schematu
+    KICAD_VERSION : Wersja KiCad
+    COMPONENT : Komponent
+    COMPONENT_GROUPS : Grupy komponentów
+    COMPONENT_COUNT_PER_PCB : Liczba komponentów (na 1 PCB)
+    FITTED_COMPONENTS_PER_PCB : Komponenty montowane (na 1 PCB)
+    NUMBER_OF_PCBS : Liczba PCB
+    TOTAL_COMPONENT_COUNT : Łączna liczba komponentów
+    FOR : dla
+    PCBS : PCB
+    KICAD_FIELDS_DEFAULT : Pola KiCad (domyślne)
+    GENERATED_FIELDS : Pola wygenerowane
+    USER_FIELDS : Pola użytkownika
+    EMPTY_FIELDS : Pola puste
+
+_COLUMNS:
+    References : Oznaczenia
+    Description : Opis
+    Value : Wartość
+    Footprint : Footprint
+    Footprint Lib : Biblioteka footprint'u
+    Part : Element
+    Part Lib : Biblioteka elementu
+    Datasheet : Dokumentacja
+    Quantity Per PCB : Liczba elementów na PCB
+    Total Cost : Łączny koszt
+    Build Quantity : Łączna liczba elementów


### PR DESCRIPTION
I just need to change some headings and column titles to my native language but ended up with modifications in the whole script to support headings/titles/labels internationalization. Translations are stored as YAML files in 'languages' folder. You can choose language with `-l` or  `--language` CLI option or `language` option in ini file. Currently there are only two files: `en.yaml` for original English messages and `pl.yaml` for my native Polish language.
Implementing internationalization causes some other minor changes because of encoding/decoding Python mangling. I've also modified original messages a little bit to unify them in every output file type.