### PR TITLE
Display "~" as empty fields

### DIFF
--- a/bomlib/html_writer.py
+++ b/bomlib/html_writer.py
@@ -113,7 +113,7 @@ def WriteHTML(filename, groups, net, headings, prefs):
 
             for n, r in enumerate(row):
 
-                if len(r) == 0:
+                if (len(r) == 0) or (r.strip() == "~"):
                     bg = BG_EMPTY
                 else:
                     bg = bgColor(headings[n])


### PR DESCRIPTION
The KiCad symbol libraries use `~` to denote certain fields as "empty" eg. when there is no datasheet. Not sure why exactly, I guess something breaks when it is *actually* empty. I think KiBoM should give these a red background.

![tilde](https://user-images.githubusercontent.com/4781841/55283679-2f0b5000-53b4-11e9-92f9-972b73cb543b.png)
