### PR TITLE
Add flag to output variant name to BoM filename

### DIFF
--- a/KiBOM_CLI.py
+++ b/KiBOM_CLI.py
@@ -32,7 +32,7 @@ except:
     xlsxwriter_available = False
 else:
     xlsxwriter_available = True
-      
+
 #
 here = os.path.abspath(os.path.dirname(sys.argv[0]))
 
@@ -57,7 +57,7 @@ def say(*arg):
 
 def isExtensionSupported(filename):
     result = False
-    extensions = [".xml",".csv",".txt",".tsv",".html"]      
+    extensions = [".xml",".csv",".txt",".tsv",".html"]
     if xlsxwriter_available:
         extensions.append(".xlsx")
     for e in extensions:
@@ -174,6 +174,13 @@ if write_to_bom:
         fext = fsplit[-1]
 
         output_file = str(fname) + "_" + str(net.getVersion()) + "." + fext
+
+    if pref.includeVariantName and args.variant is not None:
+        fsplit = output_file.split(".")
+        fname = ".".join(fsplit[:-1])
+        fext = fsplit[-1]
+
+        output_file = str(fname) + "_(" + str(args.variant) + ")" + "." + fext
 
     output_file = os.path.abspath(output_file)
 

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ optional arguments:
 
 **-r --variant** Specify the PCB *variant(s)*. Support for arbitrary PCB variants allows individual components to be marked as 'fitted' or 'not fitted' in a given variant. You can provide muliple variants comma-separated.
 
-**--cfg** If provided, this is the BOM config file that will be used. If not provided, options will be loaded from "bom.ini"
+**--cfg** If provided, this is the BoM config file that will be used. If not provided, options will be loaded from "bom.ini"
 
 **-s --separator** Override the delimiter for CSV or TSV generation
 
@@ -81,13 +81,13 @@ When you start the KiCad schematic editor and choose *Tools>Generate Bill of Mat
 
 If you want other than .csv format, edit the *Command Line*, for example inserting ".html" after the "%O".
 
-If you want more columns in your BOM, before you generate your BOM, in the schematic editor choose *Preferences>Schematic Editor Options*  and create new rows in the *Template Field Names* tab.  Then edit your components and fill in the fields.  KiBOM will reasonably sum rows in the BOM having the same values in your fields.  For example, if you have two components both with Vendor=Digikey and SKU=877-5309 (and value and footprints equal), there will be one row with Quantity "2" and References e.g. "R1, R2."
+If you want more columns in your BoM, before you generate your BoM, in the schematic editor choose *Preferences>Schematic Editor Options*  and create new rows in the *Template Field Names* tab.  Then edit your components and fill in the fields.  KiBoM will reasonably sum rows in the BoM having the same values in your fields.  For example, if you have two components both with Vendor=Digikey and SKU=877-5309 (and value and footprints equal), there will be one row with Quantity "2" and References e.g. "R1, R2."
 
 ## Features
 
 ### Intelligent Component Grouping
 
-To be useful for ordering components, the BoM output from a KiCad project should be organized into sensible component groups. By default, KiBom groups components based on the following factors:
+To be useful for ordering components, the BoM output from a KiCad project should be organized into sensible component groups. By default, KiBoM groups components based on the following factors:
 
 * Part name: (e.g. 'R' for resistors, 'C' for capacitors, or longer part names such as 'MAX232') *note: parts such as {'R','r_small'} (which are different symbol representations for the same component) can also be grouped together*
 * Value: Components must have the same value to be grouped together
@@ -206,7 +206,8 @@ BoM generation options can be configured (on a per-project basis) by editing the
 * `test_regex` : If this option is set, each component group row is test against a list of (user configurable) regular expressions. If any matches are found, that row is excluded from the output BoM file.
 * `merge_blank_field` : If this option is set, blank fields are able to be merged with non-blank fields (and do not count as a 'conflict')
 * `fit_field` : This is the name of the part field used to determine if the component is fitted, or not.
-* `include_version_number` : If this option is set, the schematic version number will be appended to the BOM filename (before the extension). e.g. `PRJBOM.csv` will become `PRJBOM_REV.csv`
+* `include_version_number` : If this option is set, the schematic version number will be appended to the BoM filename (before the extension). e.g. `PRJBOM.csv` will become `PRJBOM_REV.csv`.
+* `include_variant_name` : If this option is set, the variant name(s) will be appended to the BoM filename (before the extension). e.g. `PRJBOM.csv` will become `PRJBOM_(VARIANT(s))`, or `PRJBOM_REV.csv` will become `PRJBOM_REV_(VARIANT(s)).csv`. Where if more than one variant is used, they will be comma separated.
 
 * `IGNORE_COLUMNS` : A list of columns can be marked as 'ignore', and will not be output to the BoM file. By default, the *Part_Lib* and *Footprint_Lib* columns are ignored.
 * `GROUP_FIELDS` : A list of component fields used to group components together.
@@ -229,6 +230,10 @@ group_connectors = 1
 test_regex = 1
 ; If 'merge_blank_fields' option is set to 1, component groups with blank fields will be merged into the most compatible group, where possible
 merge_blank_fields = 1
+; If 'include_version_number' option is set to 1, the version number will be appended to the BoM filename.
+include_version_number = 1
+; If 'include_variant_name' option is set to 1, the variant name(s) will be appended to the BoM filename.
+include_variant_name = 1
 ; Field name used to determine if a particular part is to be fitted
 fit_field = Config
 

--- a/README.md
+++ b/README.md
@@ -390,3 +390,4 @@ With thanks to the following contributors:
 * https://github.com/Swij
 * https://github.com/Ximi1970
 * https://github.com/AngusP
+* https://github.com/trentks

--- a/bomlib/preferences.py
+++ b/bomlib/preferences.py
@@ -28,6 +28,7 @@ class BomPref:
     OPT_IGNORE_DNF = "ignore_dnf"
     OPT_BACKUP = "make_backup"
     OPT_INCLUDE_VERSION = "include_version_number"
+    OPT_INCLUDE_VARIANT = "include_variant_name"
     OPT_DEFAULT_BOARDS = "number_boards"
     OPT_DEFAULT_PCBCONFIG = "board_variant"
 
@@ -58,6 +59,7 @@ class BomPref:
 
         self.separatorCSV = None
         self.includeVersionNumber = True
+        self.includeVariantName = True
 
         self.xlsxwriter_available = False
         self.xlsxwriter2_available = False
@@ -131,6 +133,7 @@ class BomPref:
                 self.useRegex = self.checkOption(cf, self.OPT_USE_REGEX, default=True)
                 self.mergeBlankFields = self.checkOption(cf, self.OPT_MERGE_BLANK, default=True)
                 self.includeVersionNumber = self.checkOption(cf, self.OPT_INCLUDE_VERSION, default=True)
+                self.includeVariantName = self.checkOption(cf, self.OPT_INCLUDE_VARIANT, default=True)
 
             if cf.has_option(self.SECTION_GENERAL, self.OPT_CONFIG_FIELD):
                 self.configField = cf.get(self.SECTION_GENERAL, self.OPT_CONFIG_FIELD)
@@ -207,7 +210,7 @@ class BomPref:
 
         cf.set(self.SECTION_GENERAL, '; Make a backup of the bom before generating the new one, using the following template')
         cf.set(self.SECTION_GENERAL, self.OPT_BACKUP, self.backup)
-        
+
         cf.set(self.SECTION_GENERAL, '; Default number of boards to produce if none given on CLI with -n')
         cf.set(self.SECTION_GENERAL, self.OPT_DEFAULT_BOARDS, self.boards)
 


### PR DESCRIPTION
Hi @SchrodingersGat,

Just following up from yesterdays pull you did for #37 which added support for multiple variants. I had seen the value in adding these variants names to the BoM filename, and @AngusP (author of #37) had intended himself to add support for this. I believe this patch I have written satisfies this feature. 

There is a certain amount of personal preference when it comes to how this variant name actually gets included in the filename so in particular I would advise that you review line 183 of `KiBOM_CLI.py` (and therefore line 210 of `README.md`).

Cheers.

# Changes made:

Changes to `KiBOM_CLI.py`:

- Add logic to include variant name in filename if flag is set.
- Clean up some rogue whitespace.

Changes to `README.md`:

- Add description for new `includeVariantName` flag.
- Add `include_variant_name` flag to default `bom.ini`.
- Fix inconsistencies in capitalisation of "BoM".
- Add missing `include_version_number` flag to default `bom.ini`.

Changes to `bomlib/preferences.py`:

- Add support for `include_variant_name`, `includeVariantName` where
  appropriate