### PR TITLE
Add support for arbitrary filenames

### DIFF
--- a/KiBOM_CLI.py
+++ b/KiBOM_CLI.py
@@ -174,7 +174,7 @@ if write_to_bom:
 
     # Make replacements to custom file_name.
     file_name = pref.outputFileName
-    print("pref.outputFileName: ", pref.outputFileName)
+
     file_name = file_name.replace("%O", output_name)
     file_name = file_name.replace("%v", net.getVersion())
     if args.variant is not None:

--- a/KiBOM_CLI.py
+++ b/KiBOM_CLI.py
@@ -160,7 +160,7 @@ if write_to_bom:
     output_file = args.output
 
     if output_file is None:
-        output_path = input_file.replace(".xml",".csv")
+        output_file = input_file.replace(".xml",".csv")
 
     output_path, output_name = os.path.split(output_file)
     output_name, output_ext = os.path.splitext(output_name)

--- a/KiBOM_CLI.py
+++ b/KiBOM_CLI.py
@@ -165,9 +165,6 @@ if write_to_bom:
     output_path, output_name = os.path.split(output_file)
     output_name, output_ext = os.path.splitext(output_name)
 
-    print("output_path: ", output_path, "output_name: ", output_name, "output_ext: ", output_ext)
-    # output_file = prefs.output_file_name
-
     # KiCad BOM dialog by default passes "%O" without an extension. Append our default
     if not isExtensionSupported(output_ext):
         output_ext = ".csv"

--- a/KiBOM_CLI.py
+++ b/KiBOM_CLI.py
@@ -157,31 +157,33 @@ result = True
 
 #Finally, write the BoM out to file
 if write_to_bom:
-
     output_file = args.output
 
     if output_file is None:
-        output_file = input_file.replace(".xml","_bom.csv")
+        output_path = input_file.replace(".xml",".csv")
+
+    output_path, output_name = os.path.split(output_file)
+    output_name, output_ext = os.path.splitext(output_name)
+
+    print("output_path: ", output_path, "output_name: ", output_name, "output_ext: ", output_ext)
+    # output_file = prefs.output_file_name
 
     # KiCad BOM dialog by default passes "%O" without an extension. Append our default
-    if not isExtensionSupported(output_file):
-        output_file += "_bom.csv"
+    if not isExtensionSupported(output_ext):
+        output_ext = ".csv"
 
-    # If required, append the schematic version number to the filename
-    if pref.includeVersionNumber:
-        fsplit = output_file.split(".")
-        fname = ".".join(fsplit[:-1])
-        fext = fsplit[-1]
+    # Make replacements to custom file_name.
+    file_name = pref.outputFileName
+    print("pref.outputFileName: ", pref.outputFileName)
+    file_name = file_name.replace("%O", output_name)
+    file_name = file_name.replace("%v", net.getVersion())
+    if args.variant is not None:
+        file_name = file_name.replace("%V", pref.variantFileNameFormat)
+        file_name = file_name.replace("%V", args.variant)
+    else:
+        file_name = file_name.replace("%V", "")
 
-        output_file = str(fname) + "_" + str(net.getVersion()) + "." + fext
-
-    if pref.includeVariantName and args.variant is not None:
-        fsplit = output_file.split(".")
-        fname = ".".join(fsplit[:-1])
-        fext = fsplit[-1]
-
-        output_file = str(fname) + "_(" + str(args.variant) + ")" + "." + fext
-
+    output_file = os.path.join(output_path,file_name+output_ext)
     output_file = os.path.abspath(output_file)
 
     say("Output:",output_file)

--- a/KiBOM_CLI.py
+++ b/KiBOM_CLI.py
@@ -66,6 +66,80 @@ def isExtensionSupported(filename):
             break
     return result
 
+def writeVariant(variant, subdirectory):
+    if variant is not None:
+        pref.pcbConfig = set(map(lambda x: x.strip().lower(), variant.split(",")))
+    print("PCB variant: ", ", ".join(pref.pcbConfig))
+
+    #write preference file back out (first run will generate a file with default preferences)
+    if not have_cfile:
+        pref.Write(config_file)
+        say("Writing preferences file %s"%(config_file,))
+
+    #individual components
+    components = []
+
+    #component groups
+    groups = []
+
+    #read out the netlist
+    net = netlist(input_file, prefs = pref)
+
+    #extract the components
+    components = net.getInterestingComponents()
+
+    #group the components
+    groups = net.groupComponents(components)
+
+    columns = ColumnList(pref.corder)
+
+    #read out all available fields
+    for g in groups:
+        for f in g.fields:
+            columns.AddColumn(f)
+
+    #don't add 'boards' column if only one board is specified
+    if pref.boards <= 1:
+        columns.RemoveColumn(ColumnList.COL_GRP_BUILD_QUANTITY)
+        say("Removing:",ColumnList.COL_GRP_BUILD_QUANTITY)
+
+    #Finally, write the BoM out to file
+    if write_to_bom:
+        output_file = args.output
+
+        if output_file is None:
+            output_file = input_file.replace(".xml",".csv")
+
+        output_path, output_name = os.path.split(output_file)
+        output_name, output_ext = os.path.splitext(output_name)
+
+        # KiCad BOM dialog by default passes "%O" without an extension. Append our default
+        if not isExtensionSupported(output_ext):
+            output_ext = ".csv"
+
+        # Make replacements to custom file_name.
+        file_name = pref.outputFileName
+
+        file_name = file_name.replace("%O", output_name)
+        file_name = file_name.replace("%v", net.getVersion())
+        if variant is not None:
+            file_name = file_name.replace("%V", pref.variantFileNameFormat)
+            file_name = file_name.replace("%V", variant)
+        else:
+            file_name = file_name.replace("%V", "")
+
+        if args.subdirectory is not None:
+            output_path = os.path.join(output_path,args.subdirectory)
+            if not os.path.exists(os.path.abspath(output_path)):
+                os.makedirs(os.path.abspath(output_path))
+
+        output_file = os.path.join(output_path,file_name+output_ext)
+        output_file = os.path.abspath(output_file)
+
+        say("Output:",output_file)
+
+        return WriteBoM(output_file, groups, net, columns.columns, pref)
+
 parser = argparse.ArgumentParser(description="KiBOM Bill of Materials generator script")
 
 parser.add_argument("netlist", help='xml netlist file. Use "%%I" when running from within KiCad')
@@ -73,6 +147,7 @@ parser.add_argument("output",  default="", help='BoM output file name.\nUse "%%O
 parser.add_argument("-n", "--number", help="Number of boards to build (default = 1)", type=int, default=None)
 parser.add_argument("-v", "--verbose", help="Enable verbose output", action='count')
 parser.add_argument("-r", "--variant", help="Board variant(s), used to determine which components are output to the BoM. Comma-separate for multiple.", type=str, default=None)
+parser.add_argument("-d", "--subdirectory", help="Subdirectory within which to store the generated BoM files.", type=str, default=None)
 parser.add_argument("--cfg", help="BoM config file (script will try to use 'bom.ini' if not specified here)")
 parser.add_argument("-s","--separator",help="CSV Separator (default ',')",type=str, default=None)
 
@@ -115,79 +190,17 @@ if args.number is not None:
     pref.boards = args.number
 pref.separatorCSV = args.separator
 
-if args.variant is not None:
-    pref.pcbConfig = set(map(lambda x: x.strip().lower(), args.variant.split(",")))
-print("PCB variant: ", ", ".join(pref.pcbConfig))
-
-#write preference file back out (first run will generate a file with default preferences)
-if not have_cfile:
-    pref.Write(config_file)
-    say("Writing preferences file %s"%(config_file,))
-
-#individual components
-components = []
-
-#component groups
-groups = []
-
-#read out the netlist
-net = netlist(input_file, prefs = pref)
-
-#extract the components
-components = net.getInterestingComponents()
-
-#group the components
-groups = net.groupComponents(components)
-
-columns = ColumnList(pref.corder)
-
-#read out all available fields
-for g in groups:
-    for f in g.fields:
-        columns.AddColumn(f)
-
-#don't add 'boards' column if only one board is specified
-if pref.boards <= 1:
-    columns.RemoveColumn(ColumnList.COL_GRP_BUILD_QUANTITY)
-    say("Removing:",ColumnList.COL_GRP_BUILD_QUANTITY)
-
 #todo
 write_to_bom = True
-result = True
 
-#Finally, write the BoM out to file
-if write_to_bom:
-    output_file = args.output
-
-    if output_file is None:
-        output_file = input_file.replace(".xml",".csv")
-
-    output_path, output_name = os.path.split(output_file)
-    output_name, output_ext = os.path.splitext(output_name)
-
-    # KiCad BOM dialog by default passes "%O" without an extension. Append our default
-    if not isExtensionSupported(output_ext):
-        output_ext = ".csv"
-
-    # Make replacements to custom file_name.
-    file_name = pref.outputFileName
-
-    file_name = file_name.replace("%O", output_name)
-    file_name = file_name.replace("%v", net.getVersion())
-    if args.variant is not None:
-        file_name = file_name.replace("%V", pref.variantFileNameFormat)
-        file_name = file_name.replace("%V", args.variant)
-    else:
-        file_name = file_name.replace("%V", "")
-
-    output_file = os.path.join(output_path,file_name+output_ext)
-    output_file = os.path.abspath(output_file)
-
-    say("Output:",output_file)
-
-    result = WriteBoM(output_file, groups, net, columns.columns, pref)
-
-if result:
-    sys.exit(0)
+if args.variant is not None:
+    variants = args.variant.split(';')
 else:
-    sys.exit(-1)
+    variants = [None]
+
+for variant in variants:
+    result = writeVariant(variant, args)
+    if not result:
+        sys.exit(-1)
+
+sys.exit(0)

--- a/README.md
+++ b/README.md
@@ -206,9 +206,11 @@ BoM generation options can be configured (on a per-project basis) by editing the
 * `test_regex` : If this option is set, each component group row is test against a list of (user configurable) regular expressions. If any matches are found, that row is excluded from the output BoM file.
 * `merge_blank_field` : If this option is set, blank fields are able to be merged with non-blank fields (and do not count as a 'conflict')
 * `fit_field` : This is the name of the part field used to determine if the component is fitted, or not.
-* `include_version_number` : If this option is set, the schematic version number will be appended to the BoM filename (before the extension). e.g. `PRJBOM.csv` will become `PRJBOM_REV.csv`.
-* `include_variant_name` : If this option is set, the variant name(s) will be appended to the BoM filename (before the extension). e.g. `PRJBOM.csv` will become `PRJBOM_(VARIANT(s))`, or `PRJBOM_REV.csv` will become `PRJBOM_REV_(VARIANT(s)).csv`. Where if more than one variant is used, they will be comma separated.
-
+* `output_file_name` : A string that allows arbitrary specification of the output file name with field replacements. Fields available:
+    - `%O` : The base output file name (pulled from kicad, or specified on command line when calling script).
+    - `%v` : version number.
+    - `%V` : variant name, note that this will be ammended according to `variant_file_name_format`.
+* `variant_file_name_format` : A string that defines the variant file format. This is a unique field as the variant is not always used/specified.
 * `IGNORE_COLUMNS` : A list of columns can be marked as 'ignore', and will not be output to the BoM file. By default, the *Part_Lib* and *Footprint_Lib* columns are ignored.
 * `GROUP_FIELDS` : A list of component fields used to group components together.
 * `COMPONENT_ALIASES` : A list of space-separated values which allows multiple schematic symbol visualisations to be consolidated.
@@ -230,10 +232,10 @@ group_connectors = 1
 test_regex = 1
 ; If 'merge_blank_fields' option is set to 1, component groups with blank fields will be merged into the most compatible group, where possible
 merge_blank_fields = 1
-; If 'include_version_number' option is set to 1, the version number will be appended to the BoM filename.
-include_version_number = 1
-; If 'include_variant_name' option is set to 1, the variant name(s) will be appended to the BoM filename.
-include_variant_name = 1
+; Specify output file name format, %O is the defined output name, %v is the version, %V is the variant name which will be ammended according to 'variant_file_name_format'.
+output_file_name = %O_bom_%v%V
+; Specify the variant file name format, this is a unique field as the variant is not always used/specified. When it is unused you will want to strip all of this.
+variant_file_name_format = _(%V)
 ; Field name used to determine if a particular part is to be fitted
 fit_field = Config
 

--- a/README.md
+++ b/README.md
@@ -40,6 +40,9 @@ optional arguments:
   -r VARIANT, --variant VARIANT
                         Board variant(s), used to determine which components are
                         output to the BoM
+  -d SUBDIRECTORY, --subdirectory SUBDIRECTORY
+                        Subdirectory (relative to output file) within which the 
+                        BoM(s) should be written.
   --cfg CFG             BoM config file (script will try to use 'bom.ini' if
                         not specified here)
   -s SEPARATOR, --separator SEPARATOR

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ optional arguments:
                         Board variant(s), used to determine which components are
                         output to the BoM
   -d SUBDIRECTORY, --subdirectory SUBDIRECTORY
-                        Subdirectory (relative to output file) within which the 
+                        Subdirectory (relative to output file) within which the
                         BoM(s) should be written.
   --cfg CFG             BoM config file (script will try to use 'bom.ini' if
                         not specified here)
@@ -176,7 +176,7 @@ e.g. if we have a PCB with three components that have the following values in th
 
 If the script is run with the flag *--variant production* then C2, R1 and R2 will be loaded.
 
-If the script is run without the *--variant production* flag, then C1, R1 and R2 will be loaded.
+If the script is run without the *--variant production* flag, then R1 and R2 will be loaded.
 
 If the script is run with the flag *--variant test*, then C1, C2 and R1 will be loaded.
 

--- a/README.md
+++ b/README.md
@@ -62,7 +62,9 @@ optional arguments:
 
 **-v --verbose** Enable extra debugging information
 
-**-r --variant** Specify the PCB *variant(s)*. Support for arbitrary PCB variants allows individual components to be marked as 'fitted' or 'not fitted' in a given variant. You can provide muliple variants comma-separated.
+**-r --variant** Specify the PCB *variant(s)*. Support for arbitrary PCB variants allows individual components to be marked as 'fitted' or 'not fitted' in a given variant. You can provide muliple variants comma-separated. You can generate multiple BoMs at once for different variants by using semicolon-separation.
+
+**-d --subdirectory** Specify a subdirectory (from the provided **output** file) into which the boms should be generated.
 
 **--cfg** If provided, this is the BoM config file that will be used. If not provided, options will be loaded from "bom.ini"
 
@@ -156,7 +158,7 @@ If a variant is specified, the value of the *fit_field* field is used to determi
 * If the *fit_field* begins with a '-' character, if will be excluded from the matching variant.
 * If the *fit_field* begins with a '+' character, if will ONLY be included in the matching variant.
 
-Multiple variants can be addressed as the *fit_field* can contain multiple comma-separated values.
+Multiple variants can be addressed as the *fit_field* can contain multiple comma-separated values. Multiple BoMs can be generated at once by using semicolon-separated values.
 
 * If you specify multiple variants
    - If the *fit_field* contains the variant beginning with a '-' character, it will be excluded irrespective of any other '+' matches.
@@ -176,6 +178,8 @@ If the script is run without the *--variant production* flag, then C1, R1 and R2
 If the script is run with the flag *--variant test*, then C1, C2 and R1 will be loaded.
 
 If the script is run with the flags *--variant production,test*, then C2 and R1 will be loaded.
+
+If the script is run with the flags *--variant production;test;production,test*, then three separate BoMs will be generated one as though it had been run with *--variant production*, one for *--variant test*, and one for *--variant production,test*.
 
 ### Regular Expression Matching
 

--- a/bomlib/preferences.py
+++ b/bomlib/preferences.py
@@ -27,8 +27,8 @@ class BomPref:
     OPT_MERGE_BLANK = "merge_blank_fields"
     OPT_IGNORE_DNF = "ignore_dnf"
     OPT_BACKUP = "make_backup"
-    OPT_INCLUDE_VERSION = "include_version_number"
-    OPT_INCLUDE_VARIANT = "include_variant_name"
+    OPT_OUTPUT_FILE_NAME = "output_file_name"
+    OPT_VARIANT_FILE_NAME_FORMAT = "variant_file_name_format"
     OPT_DEFAULT_BOARDS = "number_boards"
     OPT_DEFAULT_PCBCONFIG = "board_variant"
 
@@ -58,8 +58,8 @@ class BomPref:
         self.backup = "%O.tmp"
 
         self.separatorCSV = None
-        self.includeVersionNumber = True
-        self.includeVariantName = True
+        self.outputFileName = "%O_bom_%v%V"
+        self.variantFileNameFormat = "_(%V)"
 
         self.xlsxwriter_available = False
         self.xlsxwriter2_available = False
@@ -132,8 +132,8 @@ class BomPref:
                 self.groupConnectors = self.checkOption(cf, self.OPT_GROUP_CONN, default=True)
                 self.useRegex = self.checkOption(cf, self.OPT_USE_REGEX, default=True)
                 self.mergeBlankFields = self.checkOption(cf, self.OPT_MERGE_BLANK, default=True)
-                self.includeVersionNumber = self.checkOption(cf, self.OPT_INCLUDE_VERSION, default=True)
-                self.includeVariantName = self.checkOption(cf, self.OPT_INCLUDE_VARIANT, default=True)
+                self.outputFileName = cf.get(self.SECTION_GENERAL, self.OPT_OUTPUT_FILE_NAME)
+                self.variantFileNameFormat = cf.get(self.SECTION_GENERAL, self.OPT_VARIANT_FILE_NAME_FORMAT)
 
             if cf.has_option(self.SECTION_GENERAL, self.OPT_CONFIG_FIELD):
                 self.configField = cf.get(self.SECTION_GENERAL, self.OPT_CONFIG_FIELD)


### PR DESCRIPTION
Hi @SchrodingersGat,

I wasn't quite happy with the implementation of the filename and the inclusion of variants (#58). This implementation is far more flexible (and extensible for further options in future). See what you think. I've kept the defaults such that they produce the same file names as the existing implementation.

Cheers.

------------------------------

Patch allows for user-specification of arbitrary filename. Will work on
both the command line and from within KiCAD. Should be extensible to
allow for other fields/options to be added in future. Currently only
supports version (%v), variant name/s (%V), and base file name (%O).

- Drop options for `include_version_number` and `include_variant_name`
- Add options for `output_file_name` and `variant_file_name_format`

Some examples follows which explains motivation further.

-----------------------------------------------------------------------

With:
`output_file_name = %O_v%v%V`
`variant_file_name_format=_(option:%V)`

running:
`python "KiBoM/KiBOM_CLI.py" "%I" "%O" -r OPTNAME`

would produce:
SCHEMATICNAME_v1.0_(option:OPTNAME).csv

running:
`python "KiBoM/KiBOM_CLI.py" "%I" "%O.html"`

would produce:
`SCHEMATICNAME_v1.0.html`