### PR TITLE
Fix default bom.ini generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,6 +228,10 @@ Example configuration file (.ini format) *default values shown*
 ; General BoM options here
 ; If 'ignore_dnf' option is set to 1, rows that are not to be fitted on the PCB will not be written to the BoM file
 ignore_dnf = 1
+; If 'use_alt' option is set to 1, grouped references will be printed in the alternate compressed style eg: R1-R7,R18
+use_alt = 0
+; If 'alt_wrap' option is set to and integer N, the references field will wrap after N entries are printed
+alt_wrap = 0
 ; If 'number_rows' option is set to 1, each row in the BoM will be prepended with an incrementing row number
 number_rows = 1
 ; If 'group_connectors' option is set to 1, connectors with the same footprints will be grouped together, independent of the name of the connector
@@ -242,12 +246,32 @@ output_file_name = %O_bom_%v%V
 variant_file_name_format = _(%V)
 ; Field name used to determine if a particular part is to be fitted
 fit_field = Config
+; Make a backup of the bom before generating the new one, using the following template
+make_backup = %O.tmp
+; Default number of boards to produce if none given on CLI with -n
+number_boards = 1
+; Default PCB variant if none given on CLI with -r
+board_variant = set(['2'])
 
 [IGNORE_COLUMNS]
 ; Any column heading that appears here will be excluded from the Generated BoM
 ; Titles are case-insensitive
 Part Lib
 Footprint Lib
+
+[COLUMN_ORDER]
+; Columns will apear in the order they are listed here
+; Titles are case-insensitive
+Description
+Part
+Part Lib
+References
+Value
+Footprint
+Footprint Lib
+Quantity Per PCB
+Build Quantity
+Datasheet
 
 [GROUP_FIELDS]
 ; List of fields used for sorting individual components into groups

--- a/bomlib/preferences.py
+++ b/bomlib/preferences.py
@@ -31,7 +31,6 @@ class BomPref:
     OPT_VARIANT_FILE_NAME_FORMAT = "variant_file_name_format"
     OPT_DEFAULT_BOARDS = "number_boards"
     OPT_DEFAULT_PCBCONFIG = "board_variant"
-
     OPT_CONFIG_FIELD = "fit_field"
 
     def __init__(self):
@@ -203,7 +202,12 @@ class BomPref:
         self.addOption(cf, self.OPT_GROUP_CONN, self.groupConnectors, comment="If '{opt}' option is set to 1, connectors with the same footprints will be grouped together, independent of the name of the connector".format(opt=self.OPT_GROUP_CONN))
         self.addOption(cf, self.OPT_USE_REGEX, self.useRegex, comment="If '{opt}' option is set to 1, each component group will be tested against a number of regular-expressions (specified, per column, below). If any matches are found, the row is ignored in the output file".format(opt=self.OPT_USE_REGEX))
         self.addOption(cf, self.OPT_MERGE_BLANK, self.mergeBlankFields, comment="If '{opt}' option is set to 1, component groups with blank fields will be merged into the most compatible group, where possible".format(opt=self.OPT_MERGE_BLANK))
-        self.addOption(cf, self.OPT_INCLUDE_VERSION, self.includeVersionNumber, comment="If '{opt}' option is set to 1, the schematic version number will be appended to the filename.")
+        
+        cf.set(self.SECTION_GENERAL, "; Specify output file name format, %O is the defined output name, %v is the version, %V is the variant name which will be ammended according to 'variant_file_name_format'.")
+        cf.set(self.SECTION_GENERAL, self.OPT_OUTPUT_FILE_NAME, self.outputFileName)
+
+        cf.set(self.SECTION_GENERAL, "; Specify the variant file name format, this is a unique field as the variant is not always used/specified. When it is unused you will want to strip all of this.")
+        cf.set(self.SECTION_GENERAL, self.OPT_VARIANT_FILE_NAME_FORMAT, self.variantFileNameFormat)
 
         cf.set(self.SECTION_GENERAL, '; Field name used to determine if a particular part is to be fitted')
         cf.set(self.SECTION_GENERAL, self.OPT_CONFIG_FIELD, self.configField)


### PR DESCRIPTION
- Missed default bom.ini generation with pull #60
- Updated README.md to include an exact copy of the
  default bom.ini generated (a lot of other people
  seem to have also missed this step when adding
  their features!).

-----

This solves #62, thanks for reporting @Brian245.