### PR TITLE
+ Variants are always included in BOM

### DIFF
--- a/bomlib/component.py
+++ b/bomlib/component.py
@@ -296,7 +296,7 @@ class Component():
                 exclude = True
                 break
             if opt.startswith("+"):
-                include = include or opt[1:] in [str(cfg) for cfg in self.prefs.pcbConfig]
+                include = include and opt[1:] in [str(cfg) for cfg in self.prefs.pcbConfig]
 
         return include and not exclude
 


### PR DESCRIPTION
Fixes a bug where variants with a + suffix were added to all the variants, instead of being included only when explicitly indicated.

I had a copy of KiBom from April 2019 working beautifully, but I cloned the repo in a Docker container to do some CI and get the BoMs automatically updated and I stumbled upon this bug, where my variants (indicated with a +VarName) were being added to my BoM even when not explicitly included as the variant to get. After a bit of research, I saw that it was only present in the last push, and saw that you made some changes to that part of the code. I don't know enough about the code to be 100% sure that there aren't any other issues, but I think this fixes at least the problem with the variants with the + suffix.

Thanks for your continuous work on KiBom!