### PR TITLE
Fix UnicodeEncodeError when printing Field Conflicts

### DIFF
--- a/bomlib/component.py
+++ b/bomlib/component.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+from __future__ import unicode_literals
 
 from bomlib.columns import ColumnList
 from bomlib.preferences import BomPref
@@ -322,7 +323,7 @@ class Component():
                             ref=self.getRef(),
                             field=field_name,
                             value=field_value,
-                            reg=regex))
+                            reg=regex).encode('utf-8'))
 
                     # Found a match
                     return True
@@ -512,7 +513,7 @@ class ComponentGroup():
                 refs=self.getRefs(),
                 name=field,
                 flds=self.fields[field],
-                fld=fieldData))
+                fld=fieldData).encode('utf-8'))
             self.fields[field] += " " + fieldData
 
     def updateFields(self, usealt=False, wrapN=None):


### PR DESCRIPTION
Fixed issue https://github.com/SchrodingersGat/KiBoM/issues/73 by:
* Adding `from __future__ import unicode_literals` to turn every string literal into a unicode string by default. Could just have pre-fixed offending strings with `u`, but noticed the precedent has been set in other source files, and saves missing a string.
* Appended `.encode('utf-8')` to (potentially Unicode) strings before passing to `print`. Necessary because `sys.stdout.encoding` is set to `None`, which causes Python 2 (the one included in the KiCad package) to default to trying to encode as 'ascii', which fails. Alternatively, could have changed the default encoding (either by via `PYTHONIOENCODING` environment variable, or with the `sys.setdefaultencoding` hack) but was scared away by the many, many warnings, such as here: https://stackoverflow.com/a/34378962/3697870