### PR TITLE
Add (optional) database support for adding or modifying fields

### DIFF
--- a/KiBOM_CLI.py
+++ b/KiBOM_CLI.py
@@ -109,7 +109,7 @@ def writeVariant(variant, subdirectory):
             for q in pref.db_queries:
                 field_name = q[0]
                 field_value = DBQuery(q[1:], c, pref)
-                if field_name.lower() !=  "none":
+                if field_name.lower() != "none":
                     c.setField(field_name, field_value)
             break
 

--- a/KiBOM_CLI.py
+++ b/KiBOM_CLI.py
@@ -37,7 +37,7 @@ except:
 else:
     xlsxwriter_available = True
 
-    
+
 def is_module_available(module_name):
     if sys.version_info < (3, 0):
         # python 2

--- a/KiBOM_CLI.py
+++ b/KiBOM_CLI.py
@@ -37,12 +37,21 @@ except:
 else:
     xlsxwriter_available = True
 
-try:
-    import mysql.connector
-except:
-    mysql_available = False
-else:
-    mysql_available = True
+def is_module_available(module_name):
+    if sys.version_info < (3, 0):
+        # python 2
+        import importlib
+        loader = importlib.find_loader(module_name)
+    elif sys.version_info <= (3, 3):
+        # python 3.0 to 3.3
+        import pkgutil
+        loader = pkgutil.find_loader(module_name)
+    elif sys.version_info >= (3, 4):
+        # python 3.4 and above
+        from importlib import util
+        loader = util.find_spec(module_name)
+
+    return loader is not None
 
 here = os.path.abspath(os.path.dirname(sys.argv[0]))
 
@@ -51,7 +60,6 @@ sys.path.append(os.path.join(here, "KiBOM"))
 
 
 verbose = False
-
 
 def close(*arg):
     print(*arg)
@@ -208,7 +216,7 @@ if args.cfg:
 # Read preferences from file. If file does not exists, default preferences will be used
 pref = BomPref()
 
-pref.mysql_available = mysql_available
+pref.mysql_available = is_module_available('mysql.connector')
 
 have_cfile = os.path.exists(config_file)
 if have_cfile:

--- a/KiBOM_CLI.py
+++ b/KiBOM_CLI.py
@@ -37,6 +37,7 @@ except:
 else:
     xlsxwriter_available = True
 
+    
 def is_module_available(module_name):
     if sys.version_info < (3, 0):
         # python 2
@@ -60,6 +61,7 @@ sys.path.append(os.path.join(here, "KiBOM"))
 
 
 verbose = False
+
 
 def close(*arg):
     print(*arg)

--- a/bomlib/component.py
+++ b/bomlib/component.py
@@ -292,7 +292,7 @@ class Component():
         # Footprint library is first element
         elif name.lower() == ColumnList.COL_FP_LIB.lower():
             fp = self.getFootprint().split(":")
-            self.setFootprint(value+':'+fp[1])
+            self.setFootprint(value + ':' + fp[1])
             return
 
         elif name.lower() == ColumnList.COL_FP.lower():
@@ -317,7 +317,7 @@ class Component():
                 if field == "" and libraryToo:
                     field = self.libpart.setField(f, value)
                 else:
-                  self.element.set("field", "", "name", value)
+                    self.element.set("field", "", "name", value)
                 return
 
         # Could not find a matching field. Add a new field
@@ -459,7 +459,7 @@ class Component():
 
     def setDatasheet(self, value, libraryToo=True):
         ret = self.element.get("datasheet")
-        if  "".__eq__(ret) and libraryToo:
+        if "".__eq__(ret) and libraryToo:
             self.libpart.setDatasheet(value)
         else:
             self.element.set("datasheet", value, "", libraryToo)

--- a/bomlib/database.py
+++ b/bomlib/database.py
@@ -2,6 +2,7 @@
 
 try:
     import mysql.connector
+    from mysql.connector import errorcode
 except:
     pass
 
@@ -58,9 +59,9 @@ def DBQuery(q, c, prefs):
         if q_elem == '{':  # '{' is the mark for parameter value
             params = {}
             continue
-        if q_elem == '}': # '}' is the mark for end parameter name-value tuple, so this query ends.
+        if q_elem == '}':  # '}' is the mark for end parameter name-value tuple, so this query ends.
             break
-        if query.startswith('CALL ') and q_elem == '(':  # '{' is the mark for args 
+        if query.startswith('CALL ') and q_elem == '(':  # '{' is the mark for args
             args = []
             continue
         if args is not None and q_elem == ')':  # '}' is the mark for end parameter name-value tuple, so this query ends.
@@ -101,10 +102,10 @@ def DBQuery(q, c, prefs):
                 return_value = ""
                 for result in prefs.db_cursor.stored_results():
                     for item in result.fetchall():
-                      if "".__eq__(return_value):
-                          return_value = ' '.join(item)
-                      else:
-                          return_value = return_value + ',' + ' '.join(item)
+                        if "".__eq__(return_value):
+                            return_value = ' '.join(item)
+                        else:
+                            return_value = return_value + ',' + ' '.join(item)
                 if prefs.verbose:
                     print("Procedure returned: " + return_value)
                 return(return_value)
@@ -114,9 +115,9 @@ def DBQuery(q, c, prefs):
                     print("with arguments: ")
                     print(params)
                 try:
-                    prefs.db_cursor.execute(query, params, multi = True)
+                    prefs.db_cursor.execute(query,params,multi = True)
                 except mysql.connector.Error as err:
-                    print("Database access error: "+str(err))
+                    print("Database access error: " + str(err))
                     return ""
                 return_tuple = prefs.db_cursor.fetchone()
                 if return_tuple is not None:

--- a/bomlib/database.py
+++ b/bomlib/database.py
@@ -115,7 +115,7 @@ def DBQuery(q, c, prefs):
                     print("with arguments: ")
                     print(params)
                 try:
-                    prefs.db_cursor.execute(query,params,multi = True)
+                    prefs.db_cursor.execute(query, params, multi=True)
                 except mysql.connector.Error as err:
                     print("Database access error: " + str(err))
                     return ""

--- a/bomlib/database.py
+++ b/bomlib/database.py
@@ -90,7 +90,11 @@ def DBQuery(q, c, prefs):
                       print("Calling database stored procedure: "+query)
                       print("with arguments: ")
                       print(args)
-                  return_tuple = prefs.db_cursor.callproc(query, args)
+                  try:
+                      return_tuple = prefs.db_cursor.callproc(query, args)
+                  except mysql.connector.Error as err:
+                      print("Database access error: "+str(err))
+                      return ""
                   return_value=""
                   for result in prefs.db_cursor.stored_results():
                       for item in result.fetchall():
@@ -106,7 +110,11 @@ def DBQuery(q, c, prefs):
                       print("Executing database query: "+query)
                       print("with arguments: ")
                       print(params)
-                  prefs.db_cursor.execute(query, params, multi=True)
+                  try:
+                      prefs.db_cursor.execute(query, params, multi=True)
+                  except mysql.connector.Error as err:
+                      print("Database access error: "+str(err))
+                      return ""
                   return_tuple = prefs.db_cursor.fetchone()
                   if return_tuple is not None:
                       return return_tuple[0]

--- a/bomlib/database.py
+++ b/bomlib/database.py
@@ -1,0 +1,114 @@
+# -*- coding: utf-8 -*-
+
+try:
+    import mysql.connector
+except:
+    pass
+
+def DBConnect(prefs):
+    """
+    Connect to a mysql database. Database data is stored in prefs.
+    """
+    db_config = {
+        'user': prefs.db_user,
+        'password': prefs.db_pass,
+        'host': prefs.db_host,
+        'database': prefs.db_db,
+        'raise_on_warnings': True,
+        'use_pure': False,
+    }
+
+    if prefs.mysql_available:
+      if "".__ne__(prefs.db_user) and "".__ne__(prefs.db_pass) and "".__ne__(prefs.db_host) and "".__ne__(prefs.db_db):
+          try:
+             print ("Connecting to database...")
+             prefs.db_cnx = mysql.connector.connect(**db_config)
+             print ("Connected!")
+             prefs.db_cursor = prefs.db_cnx.cursor(buffered=True)
+          except mysql.connector.Error as err:
+            if err.errno == errorcode.ER_ACCESS_DENIED_ERROR:
+              print("Database connection error: something is wrong with your user name or password")
+            elif err.errno == errorcode.ER_BAD_DB_ERROR:
+              print("Database does not exist")
+            else:
+              print(err)
+
+def DBDisconnect(prefs):
+    """
+    Disconnect from a mysql database.
+    """
+    if prefs.mysql_available:
+        if prefs.db_cnx is not None:
+            prefs.db_cnx.commit()
+        if prefs.db_cursor is not None:
+            prefs.db_cursor.close()
+        if prefs.db_cnx is not None:
+            prefs.db_cnx.close()
+
+def DBQuery(q, c, prefs):
+        query = ""
+        params = None
+        param_name = None
+        param_value = None
+        args = None
+        for q_elem in q:
+              if q_elem == '{':  # '{' is the mark for parameter value
+                  params = {}
+                  continue
+              if q_elem == '}': # '}' is the mark for end parameter name-value tuple, so this query ends.
+                  break
+              if query.startswith('CALL ') and q_elem == '(':  # '{' is the mark for args 
+                  args = []
+                  continue
+              if args is not None and q_elem == ')': # '}' is the mark for end parameter name-value tuple, so this query ends.
+                  break
+              
+              if params or args is None:
+                  query = query+q_elem + ' '
+              elif args is None:
+                  if param_name is None:
+                      param_name = q_elem
+                  else:
+                      if q_elem.startswith('$'): # Then evaluate this value
+                        param_value = eval(q_elem[1:], {'__builtins__': None}, {'component': c})
+                      else:
+                        param_value = q_elem
+                  if param_name is not None and param_value is not None:
+                      params.update({param_name: param_value})
+                      param_name = None
+                      param_value = None
+              elif args is not None:
+                  if q_elem.startswith('$'): # Then evaluate this value
+                      q_elem = eval(q_elem[1:], {'__builtins__': None}, {'component': c})
+                  args.append(q_elem)
+
+        if prefs.mysql_available:
+          if prefs.db_cursor is not None:
+              if 'call '.__eq__(query[0:5].lower()):
+                  query = query[5:].strip()
+                  if prefs.verbose:
+                      print("Calling database stored procedure: "+query)
+                      print("with arguments: ")
+                      print(args)
+                  return_tuple = prefs.db_cursor.callproc(query, args)
+                  return_value=""
+                  for result in prefs.db_cursor.stored_results():
+                      for item in result.fetchall():
+                        if "".__eq__(return_value):
+                            return_value = ' '.join(item)
+                        else:
+                            return_value = return_value + ','+' '.join(item)
+                  if prefs.verbose:
+                      print("Procedure returned: "+return_value)
+                  return(return_value)
+              else:
+                  if prefs.verbose:
+                      print("Executing database query: "+query)
+                      print("with arguments: ")
+                      print(params)
+                  prefs.db_cursor.execute(query, params, multi=True)
+                  return_tuple = prefs.db_cursor.fetchone()
+                  if return_tuple is not None:
+                      return return_tuple[0]
+                  else:
+                      return ""

--- a/bomlib/database.py
+++ b/bomlib/database.py
@@ -5,6 +5,7 @@ try:
 except:
     pass
 
+
 def DBConnect(prefs):
     """
     Connect to a mysql database. Database data is stored in prefs.
@@ -19,19 +20,20 @@ def DBConnect(prefs):
     }
 
     if prefs.mysql_available:
-      if "".__ne__(prefs.db_user) and "".__ne__(prefs.db_pass) and "".__ne__(prefs.db_host) and "".__ne__(prefs.db_db):
-          try:
-             print ("Connecting to database...")
-             prefs.db_cnx = mysql.connector.connect(**db_config)
-             print ("Connected!")
-             prefs.db_cursor = prefs.db_cnx.cursor(buffered=True)
-          except mysql.connector.Error as err:
-            if err.errno == errorcode.ER_ACCESS_DENIED_ERROR:
-              print("Database connection error: something is wrong with your user name or password")
-            elif err.errno == errorcode.ER_BAD_DB_ERROR:
-              print("Database does not exist")
-            else:
-              print(err)
+        if "".__ne__(prefs.db_user) and "".__ne__(prefs.db_pass) and "".__ne__(prefs.db_host) and "".__ne__(prefs.db_db):
+            try:
+                print("Connecting to database...")
+                prefs.db_cnx = mysql.connector.connect(**db_config)
+                print("Connected!")
+                prefs.db_cursor = prefs.db_cnx.cursor(buffered=True)
+            except mysql.connector.Error as err:
+                if err.errno == errorcode.ER_ACCESS_DENIED_ERROR:
+                    print("Database connection error: something is wrong with your user name or password")
+                elif err.errno == errorcode.ER_BAD_DB_ERROR:
+                    print("Database does not exist")
+                else:
+                    print(err)
+
 
 def DBDisconnect(prefs):
     """
@@ -45,78 +47,79 @@ def DBDisconnect(prefs):
         if prefs.db_cnx is not None:
             prefs.db_cnx.close()
 
-def DBQuery(q, c, prefs):
-        query = ""
-        params = None
-        param_name = None
-        param_value = None
-        args = None
-        for q_elem in q:
-              if q_elem == '{':  # '{' is the mark for parameter value
-                  params = {}
-                  continue
-              if q_elem == '}': # '}' is the mark for end parameter name-value tuple, so this query ends.
-                  break
-              if query.startswith('CALL ') and q_elem == '(':  # '{' is the mark for args 
-                  args = []
-                  continue
-              if args is not None and q_elem == ')': # '}' is the mark for end parameter name-value tuple, so this query ends.
-                  break
-              
-              if params or args is None:
-                  query = query+q_elem + ' '
-              elif args is None:
-                  if param_name is None:
-                      param_name = q_elem
-                  else:
-                      if q_elem.startswith('$'): # Then evaluate this value
-                        param_value = eval(q_elem[1:], {'__builtins__': None}, {'component': c})
-                      else:
-                        param_value = q_elem
-                  if param_name is not None and param_value is not None:
-                      params.update({param_name: param_value})
-                      param_name = None
-                      param_value = None
-              elif args is not None:
-                  if q_elem.startswith('$'): # Then evaluate this value
-                      q_elem = eval(q_elem[1:], {'__builtins__': None}, {'component': c})
-                  args.append(q_elem)
 
-        if prefs.mysql_available:
-          if prefs.db_cursor is not None:
-              if 'call '.__eq__(query[0:5].lower()):
-                  query = query[5:].strip()
-                  if prefs.verbose:
-                      print("Calling database stored procedure: "+query)
-                      print("with arguments: ")
-                      print(args)
-                  try:
-                      return_tuple = prefs.db_cursor.callproc(query, args)
-                  except mysql.connector.Error as err:
-                      print("Database access error: "+str(err))
-                      return ""
-                  return_value=""
-                  for result in prefs.db_cursor.stored_results():
-                      for item in result.fetchall():
-                        if "".__eq__(return_value):
-                            return_value = ' '.join(item)
-                        else:
-                            return_value = return_value + ','+' '.join(item)
-                  if prefs.verbose:
-                      print("Procedure returned: "+return_value)
-                  return(return_value)
-              else:
-                  if prefs.verbose:
-                      print("Executing database query: "+query)
-                      print("with arguments: ")
-                      print(params)
-                  try:
-                      prefs.db_cursor.execute(query, params, multi=True)
-                  except mysql.connector.Error as err:
-                      print("Database access error: "+str(err))
-                      return ""
-                  return_tuple = prefs.db_cursor.fetchone()
-                  if return_tuple is not None:
-                      return return_tuple[0]
-                  else:
-                      return ""
+def DBQuery(q, c, prefs):
+    query = ""
+    params = None
+    param_name = None
+    param_value = None
+    args = None
+    for q_elem in q:
+        if q_elem == '{':  # '{' is the mark for parameter value
+            params = {}
+            continue
+        if q_elem == '}': # '}' is the mark for end parameter name-value tuple, so this query ends.
+            break
+        if query.startswith('CALL ') and q_elem == '(':  # '{' is the mark for args 
+            args = []
+            continue
+        if args is not None and q_elem == ')':  # '}' is the mark for end parameter name-value tuple, so this query ends.
+            break
+
+        if params or args is None:
+            query = query + q_elem + ' '
+        elif args is None:
+            if param_name is None:
+                param_name = q_elem
+            else:
+                if q_elem.startswith('$'):  # Then evaluate this value
+                    param_value = eval(q_elem[1:], {'__builtins__': None}, {'component': c})
+                else:
+                    param_value = q_elem
+            if param_name is not None and param_value is not None:
+                params.update({param_name: param_value})
+                param_name = None
+                param_value = None
+        elif args is not None:
+            if q_elem.startswith('$'):  # Then evaluate this value
+                q_elem = eval(q_elem[1:], {'__builtins__': None}, {'component': c})
+            args.append(q_elem)
+
+    if prefs.mysql_available:
+        if prefs.db_cursor is not None:
+            if 'call '.__eq__(query[0:5].lower()):
+                query = query[5:].strip()
+                if prefs.verbose:
+                    print("Calling database stored procedure: " + query)
+                    print("with arguments: ")
+                    print(args)
+                try:
+                    return_tuple = prefs.db_cursor.callproc(query, args)
+                except mysql.connector.Error as err:
+                    print("Database access error: " + str(err))
+                    return ""
+                return_value = ""
+                for result in prefs.db_cursor.stored_results():
+                    for item in result.fetchall():
+                      if "".__eq__(return_value):
+                          return_value = ' '.join(item)
+                      else:
+                          return_value = return_value + ',' + ' '.join(item)
+                if prefs.verbose:
+                    print("Procedure returned: " + return_value)
+                return(return_value)
+            else:
+                if prefs.verbose:
+                    print("Executing database query: " + query)
+                    print("with arguments: ")
+                    print(params)
+                try:
+                    prefs.db_cursor.execute(query, params, multi = True)
+                except mysql.connector.Error as err:
+                    print("Database access error: "+str(err))
+                    return ""
+                return_tuple = prefs.db_cursor.fetchone()
+                if return_tuple is not None:
+                    return return_tuple[0]
+                else:
+                    return ""

--- a/bomlib/netlist_reader.py
+++ b/bomlib/netlist_reader.py
@@ -273,8 +273,7 @@ class libpart():
         return datasheet
 
     def setDatasheet(self, value):
-
-        datasheet = self.setField("Datasheet", value)
+        self.setField("Datasheet", value)
 
     def getFootprint(self):
         return self.getField("Footprint")

--- a/bomlib/netlist_reader.py
+++ b/bomlib/netlist_reader.py
@@ -138,19 +138,19 @@ class xmlElement():
             This function can not be moved to component.py due to it needs to create a new xmlElement, which is defined in this file.
             Moving it to component.py would fail due to circular dependencies. """
         fields = self.getChild('fields')
-        if not fields: # If there is no child 'flelds', then this component has no fields. Add it before adding fields
+        if not fields:  # If there is no child 'flelds', then this component has no fields. Add it before adding fields
             fields = xmlElement('fields', self)
             self.addChild(fields)
 
         child = self.getChild(name)
         if child is None:
             newChild = xmlElement('field', fields)
-            newChild.addAttribute('name', name) # Add field name
-            newChild.setChars(value) # Set field value for this component
+            newChild.addAttribute('name', name)  # Add field name
+            newChild.setChars(value)  # Set field value for this component
             fields.addChild(newChild)
             return newChild
         else:
-            newChild.setChars(value) # Set field value for this component
+            newChild.setChars(value)  # Set field value for this component
             return child
 
     def getParent(self):
@@ -201,7 +201,7 @@ class xmlElement():
 
         return ""
 
-    def set(self, elemName,  value, attribute = "", attrmatch = "" ):
+    def set(self, elemName, value, attribute="", attrmatch=""):
         """Return the text data for either an attribute or an xmlElement
         """
         if (self.name == elemName):
@@ -216,6 +216,7 @@ class xmlElement():
                 self.chars = value
         for child in self.children:
             child.set(elemName, value, attribute, attrmatch)
+
 
 class libpart():
     """Class for a library part, aka 'libpart' in the xml netlist file.

--- a/bomlib/preferences.py
+++ b/bomlib/preferences.py
@@ -389,7 +389,7 @@ class BomPref:
         cf.set(self.SECTION_DATABASE_QUERIES, ';        $component.getFootprint() : returns the footprint of the component')
         cf.set(self.SECTION_DATABASE_QUERIES, ';        $component.getField(field_name) : returns the value for this component of field named \'name\'.')
         cf.set(self.SECTION_DATABASE_QUERIES, ';     Several fields can be combined, but there should be only one \'$\' at the beginning of the expression, and no spaces between. For example:')
-        cf.set(self.SECTION_DATABASE_QUERIES, ';        $component.getValue() + '|' + component.getFootprint()   : returns a string like \'value|footprint\'')
+        cf.set(self.SECTION_DATABASE_QUERIES, ';        $component.getValue() + \'|\' + component.getFootprint()   : returns a string like \'value|footprint\'')
         cf.set(self.SECTION_DATABASE_QUERIES, ';')
 
         with open(file, 'wb') as configfile:

--- a/bomlib/preferences.py
+++ b/bomlib/preferences.py
@@ -328,6 +328,8 @@ class BomPref:
             cf.set(self.SECTION_REGEXCLUDES, i[0] + "\t" + i[1])
 
         cf.add_section(self.SECTION_DATABASE)
+        cf.set(self.SECTION_DATABASE_QUERIES, '; Database access is supported if mysql.connector python module  is installed')
+        cf.set(self.SECTION_DATABASE_QUERIES, '; See installation guide at: https://dev.mysql.com/doc/connector-python/en/connector-python-installation.html')
         cf.set(self.SECTION_DATABASE, self.OPT_DB_HOST, self.db_host )
         cf.set(self.SECTION_DATABASE, self.OPT_DB_USER, self.db_user)
         cf.set(self.SECTION_DATABASE, self.OPT_DB_PASSWORD, self.db_pass)

--- a/bomlib/preferences.py
+++ b/bomlib/preferences.py
@@ -220,8 +220,7 @@ class BomPref:
         if self.SECTION_DATABASE_QUERIES in cf.sections():
             self.regExcludes = []
             for pair in cf.options(self.SECTION_DATABASE_QUERIES):
-                #if len(re.split('[ \t]+', pair)) == 2:
-                    self.db_queries.append(re.split('[ \t]+', pair))
+                self.db_queries.append(re.split('[ \t]+', pair))
 
     # Add an option to the SECTION_GENRAL group
     def addOption(self, parser, opt, value, comment=None):
@@ -330,7 +329,7 @@ class BomPref:
         cf.add_section(self.SECTION_DATABASE)
         cf.set(self.SECTION_DATABASE_QUERIES, '; Database access is supported if mysql.connector python module  is installed')
         cf.set(self.SECTION_DATABASE_QUERIES, '; See installation guide at: https://dev.mysql.com/doc/connector-python/en/connector-python-installation.html')
-        cf.set(self.SECTION_DATABASE, self.OPT_DB_HOST, self.db_host )
+        cf.set(self.SECTION_DATABASE, self.OPT_DB_HOST, self.db_host)
         cf.set(self.SECTION_DATABASE, self.OPT_DB_USER, self.db_user)
         cf.set(self.SECTION_DATABASE, self.OPT_DB_PASSWORD, self.db_pass)
         cf.set(self.SECTION_DATABASE, self.OPT_DB_DATABASE, self.db_db)

--- a/bomlib/preferences.py
+++ b/bomlib/preferences.py
@@ -389,7 +389,7 @@ class BomPref:
         cf.set(self.SECTION_DATABASE_QUERIES, ';        $component.getFootprint() : returns the footprint of the component')
         cf.set(self.SECTION_DATABASE_QUERIES, ';        $component.getField(field_name) : returns the value for this component of field named \'name\'.')
         cf.set(self.SECTION_DATABASE_QUERIES, ';     Several fields can be combined, but there should be only one \'$\' at the beginning of the expression, and no spaces between. For example:')
-        cf.set(self.SECTION_DATABASE_QUERIES, ';        $component.getValue()+'|'+component.getFootprint()   : returns a string like \'value|footprint\'')
+        cf.set(self.SECTION_DATABASE_QUERIES, ';        $component.getValue() + '|' + component.getFootprint()   : returns a string like \'value|footprint\'')
         cf.set(self.SECTION_DATABASE_QUERIES, ';')
 
         with open(file, 'wb') as configfile:


### PR DESCRIPTION
Support is optional, if mysql.connector module is installed. It is automatically detected.

With this PR, field values can be retrieved from a database, or new fields can be created using database queries. One query is performed for each component, and there is support for including a component attribute or field's value in the query.

Queries and database stored procedures are supported. The return value can be assigned to a given field's name. If field's name is "none", return value is ignored.

Queries or calls to stored procedures are defined in bom configuration file, so they can be defined/customized by users.