### PR TITLE
Description fallback fix for KiCad 5.x

### DIFF
--- a/bomlib/component.py
+++ b/bomlib/component.py
@@ -167,15 +167,15 @@ class Component():
 
     def getDescription(self):
         try:
-            return self.element.get("libsource", "description")
+            ret = self.element.get("libsource", "description")
         except:
             # Compatibility with old KiCad versions (4.x)
             ret = self.element.get("field", "name", "description")
 
-            if ret == "":
-                ret = self.libpart.getDescription()
+        if ret == "":
+            ret = self.libpart.getDescription()
 
-            return ret
+        return ret
 
     def setValue(self, value):
         """Set the value of this component"""


### PR DESCRIPTION
The KiCad 4.x description code had a fallback to the library description.
The new one didn't have it. This patch uses the fallback for both.