### PR TITLE
Added "join" to join fields like voltage, current, etc. with the value

### DIFF
--- a/bomlib/netlist_reader.py
+++ b/bomlib/netlist_reader.py
@@ -181,6 +181,16 @@ class xmlElement():
 
         return ""
 
+    # Is it complete? Assumes the destination is a KiCad base field
+    def append(self, elemName, value):
+        """Appends text to the indicated elemName
+        """
+        for child in self.children:
+            ret = child.get(elemName)
+            if ret != "":
+                child.addChars(value)
+        return ""
+
 
 class libpart():
     """Class for a library part, aka 'libpart' in the xml netlist file.
@@ -396,6 +406,16 @@ class netlist():
     def groupComponents(self, components):
 
         groups = []
+
+        # Join fields like voltage, current, power and tolerance with the value
+        for join_l in self.prefs.join:
+            elements = len(join_l)
+            if elements > 1:
+                for j in range(1, elements):
+                    for c in components:
+                        ret = c.getField(join_l[j])
+                        if ret != "":
+                            c.element.append(join_l[0], ' ' + ret)
 
         # Iterate through each component, and test whether a group for these already exists
         for c in components:

--- a/bomlib/preferences.py
+++ b/bomlib/preferences.py
@@ -23,6 +23,7 @@ class BomPref:
     SECTION_GROUPING_FIELDS = "GROUP_FIELDS"
     SECTION_REGEXCLUDES = "REGEX_EXCLUDE"
     SECTION_REGINCLUDES = "REGEX_INCLUDE"
+    SECTION_JOIN = "JOIN"
 
     OPT_PCB_CONFIG = "pcb_configuration"
     OPT_NUMBER_ROWS = "number_rows"
@@ -106,6 +107,9 @@ class BomPref:
             ["d", "diode", "d_small"]
         ]
 
+        # Nothing to join by default
+        self.join = []
+
     # Check an option within the SECTION_GENERAL group
     def checkOption(self, parser, opt, default=False):
         if parser.has_option(self.SECTION_GENERAL, opt):
@@ -178,6 +182,10 @@ class BomPref:
         # Read out component aliases
         if self.SECTION_ALIASES in cf.sections():
             self.aliases = [re.split('[ \t]+', a) for a in cf.options(self.SECTION_ALIASES)]
+
+        # Read out join rules
+        if self.SECTION_JOIN in cf.sections():
+            self.join = [a.split("\t") for a in cf.options(self.SECTION_JOIN)]
 
         if self.SECTION_REGEXCLUDES in cf.sections():
             self.regExcludes = []
@@ -271,6 +279,15 @@ class BomPref:
 
         for a in self.aliases:
             cf.set(self.SECTION_ALIASES, "\t".join(a))
+
+        cf.add_section(self.SECTION_JOIN)
+        cf.set(self.SECTION_JOIN, "; A list of rules to join the content of fields")
+        cf.set(self.SECTION_JOIN, "; Each line is a rule, the first name is the field that will receive the data")
+        cf.set(self.SECTION_JOIN, "; from the other fields")
+        cf.set(self.SECTION_JOIN, '; Field names are case-insensitive')
+
+        for a in self.join:
+            cf.set(self.SECTION_JOIN, "\t".join(a))
 
         cf.add_section(self.SECTION_REGINCLUDES)
         cf.set(self.SECTION_REGINCLUDES, '; A series of regular expressions used to include parts in the BoM')


### PR DESCRIPTION
1 nF 50 V isn't the same as 1 nF 100 V and having separated columns for each possible modifier is an overkill. Joining the fields to the value is compact and natural. 