### PR TITLE
Fix XML writer output

### DIFF
--- a/kibom/xml_writer.py
+++ b/kibom/xml_writer.py
@@ -56,7 +56,7 @@ def WriteXML(filename, groups, net, headings, prefs):
 
             attrib[h] = str(row[i])
 
-        # sub = ElementTree.SubElement(xml, "group", attrib=attrib)
+        ElementTree.SubElement(xml, "group", attrib=attrib)
 
     with open(filename, "w") as output:
         out = ElementTree.tostring(xml, encoding="utf-8")


### PR DESCRIPTION
Line was commented out to fix an "unused variable" PEP warning. Putting the line back in.