### PR TITLE
Recover the KiBOM_CLI.py script.

### DIFF
--- a/KiBOM_CLI.py
+++ b/KiBOM_CLI.py
@@ -1,0 +1,28 @@
+#!/usr/bin/env python3
+"""
+    @package
+    KiBOM - Bill of Materials generation for KiCad
+
+    Generate BOM in xml, csv, txt, tsv, html or xlsx formats.
+
+    - Components are automatically grouped into BoM rows (grouping is configurable)
+    - Component groups count number of components and list component designators
+    - Rows are automatically sorted by component reference(s)
+    - Supports board variants
+
+    Extended options are available in the "bom.ini" config file in the PCB directory
+    (this file is auto-generated with default options the first time the script is executed).
+
+    For usage help:
+    python -m kibom -h
+"""
+
+import sys
+import os
+
+here = os.path.abspath(os.path.dirname(__file__))
+sys.path.insert(0, here)
+
+from kibom.__main__ import main  # noqa: E402
+
+main()

--- a/kibom/__main__.py
+++ b/kibom/__main__.py
@@ -101,7 +101,10 @@ def writeVariant(input_file, output_dir, output_file, variant, preferences):
 
 def main():
 
-    parser = argparse.ArgumentParser(prog="python -m kibom", description="KiBOM Bill of Materials generator script")
+    prog = 'KiBOM_CLI.py'
+    if __name__ == '__main__':
+        prog = "python -m kibom"
+    parser = argparse.ArgumentParser(prog=prog, description="KiBOM Bill of Materials generator script")
 
     parser.add_argument("netlist", help='xml netlist file. Use "%%I" when running from within KiCad')
     parser.add_argument("output", default="", help='BoM output file name.\nUse "%%O" when running from within KiCad to use the default output name (csv file).\nFor e.g. HTML output, use "%%O.html"')

--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,8 @@ setuptools.setup(
     license="MIT",
 
     packages=setuptools.find_packages(),
+ 
+    scripts=['KiBOM_CLI.py'],
 
     install_requires=[
         "xlsxwriter",


### PR DESCRIPTION
This script was lost when kibom migrated from bomlib to kibom.
Having it isn't incompatible with kibom as a module.