### PR TITLE
Avoid destroying the current locale's decimal point

### DIFF
--- a/kibom/__main__.py
+++ b/kibom/__main__.py
@@ -22,6 +22,7 @@ from __future__ import print_function
 import sys
 import os
 import argparse
+import locale
 
 from .columns import ColumnList
 from .netlist_reader import netlist
@@ -100,6 +101,7 @@ def writeVariant(input_file, output_dir, output_file, variant, preferences):
 
 
 def main():
+    locale.setlocale(locale.LC_ALL, '')
 
     parser = argparse.ArgumentParser(prog="python -m kibom", description="KiBOM Bill of Materials generator script")
 

--- a/kibom/units.py
+++ b/kibom/units.py
@@ -11,6 +11,7 @@ e.g.
 
 from __future__ import unicode_literals
 import re
+import locale
 
 PREFIX_MICRO = [u"μ", "u", "micro"]
 PREFIX_MILLI = ["milli", "m"]
@@ -29,6 +30,9 @@ UNIT_C = ["farad", "f"]
 UNIT_L = ["henry", "h"]
 
 UNIT_ALL = UNIT_R + UNIT_C + UNIT_L
+
+# Current locale decimal point value
+decimal_point = None
 
 
 def getUnit(unit):
@@ -93,6 +97,13 @@ def compMatch(component):
     e.g. compMatch("10R2") returns (10, R)
     e.g. compMatch("3.3mOhm") returns (0.0033, R)
     """
+
+    # Convert the decimal point from the current locale to a '.'
+    global decimal_point
+    if not decimal_point:
+        decimal_point = locale.localeconv()['decimal_point']
+    if decimal_point and decimal_point != '.':
+        component = component.replace(decimal_point, ".")
 
     # Remove any commas
     component = component.strip().replace(",", "").lower()


### PR DESCRIPTION
The units parser currently prunes any comma.
But for many locales this is the decimal point separator.
This patch converts the current locale decimal point into a point.