### PR TITLE
Adds an option to make a column to contain datasheet links

### DIFF
--- a/kibom/html_writer.py
+++ b/kibom/html_writer.py
@@ -52,6 +52,7 @@ def WriteHTML(filename, groups, net, headings, head_names, prefs):
     nFitted = sum([g.getCount() for g in groups if g.isFitted()])
     nBuild = nFitted * prefs.boards
 
+    link_datasheet = prefs.as_link
     link_digikey = None
     if prefs.digikey_link:
         link_digikey = prefs.digikey_link.split("\t")
@@ -137,6 +138,14 @@ def WriteHTML(filename, groups, net, headings, head_names, prefs):
                 if link_mouser and headings[n] in link_mouser:
                     r = '<a href="https://www.mouser.com/ProductDetail/' + r + '">' + r + '</a>'
 
+                # Link this column to the datasheet?
+                if link_datasheet and headings[n] == link_datasheet:
+                    r = '<a href="' + group.getField(ColumnList.COL_DATASHEET) + '">' + r + '</a>'
+
+                # Link this column to the datasheet?
+                if link_datasheet and headings[n] == link_datasheet:
+                    r = '<a href="' + group.getField(ColumnList.COL_DATASHEET) + '">' + r + '</a>'
+
                 if (len(r) == 0) or (r.strip() == "~"):
                     bg = BG_EMPTY
                 else:
@@ -180,13 +189,18 @@ def WriteHTML(filename, groups, net, headings, head_names, prefs):
                     html.write('\t<td align="center">{n}</td>\n'.format(n=rowCount))
  
                 for n, r in enumerate(row):
+
+                    # Link this column to the datasheet?
+                    if link_datasheet and headings[n] == link_datasheet:
+                        r = '<a href="' + group.getField(ColumnList.COL_DATASHEET) + '">' + r + '</a>'
+
                     if link_digikey and headings[n] in link_digikey:
                         r = '<a href="https://www.digikey.com/en/products?mpart=' + r + '">' + r + '</a>'
 
                     if link_mouser and headings[n] in link_mouser:
                         r = '<a href="https://www.mouser.com/ProductDetail/' + r + '">' + r + '</a>'
 
-                    if len(r) == 0:
+                    if (len(r) == 0) or (r.strip() == "~"):
                         bg = BG_EMPTY
                     else:
                         bg = bgColor(headings[n])

--- a/kibom/preferences.py
+++ b/kibom/preferences.py
@@ -47,6 +47,7 @@ class BomPref:
     OPT_HIDE_HEADERS = "hide_headers"
     OPT_HIDE_PCB_INFO = "hide_pcb_info"
     OPT_REF_SEPARATOR = "ref_separator"
+    OPT_DATASHEET_AS_LINK = "datasheet_as_link"
 
     def __init__(self):
         # List of headings to ignore in BoM generation
@@ -76,6 +77,7 @@ class BomPref:
         self.refSeparator = " "
 
         self.backup = "%O.tmp"
+        self.as_link = False
 
         self.separatorCSV = None
         self.outputFileName = "%O_bom_%v%V"
@@ -186,6 +188,11 @@ class BomPref:
         else:
             self.backup = False
 
+        if cf.has_option(self.SECTION_GENERAL, self.OPT_DATASHEET_AS_LINK):
+            self.as_link = cf.get(self.SECTION_GENERAL, self.OPT_DATASHEET_AS_LINK)
+        else:
+            self.as_link = False
+
         if cf.has_option(self.SECTION_GENERAL, self.OPT_HIDE_HEADERS):
             self.hideHeaders = cf.get(self.SECTION_GENERAL, self.OPT_HIDE_HEADERS) == '1'
 
@@ -283,6 +290,9 @@ class BomPref:
 
         cf.set(self.SECTION_GENERAL, '; Make a backup of the bom before generating the new one, using the following template')
         cf.set(self.SECTION_GENERAL, self.OPT_BACKUP, self.backup)
+
+        cf.set(self.SECTION_GENERAL, '; Put the datasheet as a link for the following field')
+        cf.set(self.SECTION_GENERAL, self.OPT_DATASHEET_AS_LINK, self.as_link)
 
         cf.set(self.SECTION_GENERAL, '; Default number of boards to produce if none given on CLI with -n')
         cf.set(self.SECTION_GENERAL, self.OPT_DEFAULT_BOARDS, self.boards)


### PR DESCRIPTION
Replaces #79

## Description

Having a separated column for the datasheet is an overkill. We can make
that another column contains this information as a link. The part
number is a suitable column.

This patch allows configuring it.

## How to use

Define the datasheet_as_link option in the configuration file (i.e.
bom.ini).

The value for this option is the column you want to convert into a link
to the datasheet. Example:

```
datasheet_as_link = manf#
```

This will make entries in the column manf# (manufacturer part number)
links to the datasheet.

## Limitations

Only available for HTML