### PR TITLE
Added 'digikey_link' to make a column with links to digikey P/Ns

### DIFF
--- a/kibom/html_writer.py
+++ b/kibom/html_writer.py
@@ -51,6 +51,10 @@ def WriteHTML(filename, groups, net, headings, prefs):
     nFitted = sum([g.getCount() for g in groups if g.isFitted()])
     nBuild = nFitted * prefs.boards
 
+    link_digikey = None
+    if prefs.digikey_link:
+        link_digikey = prefs.digikey_link.split("\t")
+
     with open(filename, "w") as html:
 
         # HTML Header
@@ -122,6 +126,8 @@ def WriteHTML(filename, groups, net, headings, prefs):
                 html.write('\t<td align="center">{n}</td>\n'.format(n=rowCount))
 
             for n, r in enumerate(row):
+                if link_digikey and headings[n] in link_digikey:
+                    r = '<a href="http://search.digikey.com/scripts/DkSearch/dksus.dll?Detail&name=' + r + '">' + r + '</a>'
 
                 if (len(r) == 0) or (r.strip() == "~"):
                     bg = BG_EMPTY
@@ -166,7 +172,9 @@ def WriteHTML(filename, groups, net, headings, prefs):
                     html.write('\t<td align="center">{n}</td>\n'.format(n=rowCount))
  
                 for n, r in enumerate(row):
- 
+                    if link_digikey and headings[n] in link_digikey:
+                        r = '<a href="http://search.digikey.com/scripts/DkSearch/dksus.dll?Detail&name=' + r + '">' + r + '</a>'
+
                     if len(r) == 0:
                         bg = BG_EMPTY
                     else:

--- a/kibom/preferences.py
+++ b/kibom/preferences.py
@@ -25,6 +25,7 @@ class BomPref:
     SECTION_REGEXCLUDES = "REGEX_EXCLUDE"
     SECTION_REGINCLUDES = "REGEX_INCLUDE"
 
+    OPT_DIGIKEY_LINK = "digikey_link"
     OPT_PCB_CONFIG = "pcb_configuration"
     OPT_NUMBER_ROWS = "number_rows"
     OPT_GROUP_CONN = "group_connectors"
@@ -59,6 +60,7 @@ class BomPref:
         self.groupConnectors = True  # Group connectors and ignore component value
         self.useRegex = True  # Test various columns with regex
 
+        self.digikey_link = False  # Columns to link to Digi-Key
         self.boards = 1  # Quantity of boards to be made
         self.mergeBlankFields = True  # Blanks fields will be merged when possible
         self.hideHeaders = False
@@ -163,6 +165,11 @@ class BomPref:
         if cf.has_option(self.SECTION_GENERAL, self.OPT_HIDE_PCB_INFO):
             self.hidePcbInfo = cf.get(self.SECTION_GENERAL, self.OPT_HIDE_PCB_INFO) == '1'
 
+        if cf.has_option(self.SECTION_GENERAL, self.OPT_DIGIKEY_LINK):
+            self.digikey_link = cf.get(self.SECTION_GENERAL, self.OPT_DIGIKEY_LINK)
+        else:
+            self.digikey_link = False
+
         # Read out grouping colums
         if self.SECTION_GROUPING_FIELDS in cf.sections():
             self.groups = [i for i in cf.options(self.SECTION_GROUPING_FIELDS)]
@@ -240,6 +247,9 @@ class BomPref:
 
         cf.set(self.SECTION_GENERAL, '; Whether to hide PCB info from output file')
         cf.set(self.SECTION_GENERAL, self.OPT_HIDE_PCB_INFO, self.hidePcbInfo)
+
+        cf.set(self.SECTION_GENERAL, '; Interpret as a Digikey P/N and link the following field')
+        cf.set(self.SECTION_GENERAL, self.OPT_DIGIKEY_LINK, self.digikey_link)
 
         cf.add_section(self.SECTION_IGNORE)
         cf.set(self.SECTION_IGNORE, "; Any column heading that appears here will be excluded from the Generated BoM")


### PR DESCRIPTION
## Description

Digi-Key is one of the most complete electronic parts providers. Is often used as a reference.

If you have a field containing the Digi-Key part number you can make its column to contain links to the Digi-Key web page for this component.

## How to use

Define the `digikey_link` option in the configuration file (i.e. `bom.ini`).

The value for this option is the column you want to convert into a link to the Digi-Key.
Note that this field must be a valid Digi-Key part number.
Example:

```
digikey_link = digikey#
```

This will make entries in the column `digikey#` (Digi-Key part number) links to the component's web page.

You can specify more than one fiel name using tab (ASCII 9) as separator:

```
digikey_link = digikey#	digikey_alt#
```

## Limitations

- Only available for HTML.
- Could break if Digi-Key changes it web layout. Please report any problem.

Replaces #80 using a simpler method.