### PR TITLE
Added "join" to join fields like voltage, current, etc. with the value

### DIFF
--- a/kibom/component.py
+++ b/kibom/component.py
@@ -612,6 +612,18 @@ class ComponentGroup():
         for key in columns:
             val = self.getField(key)
 
+            # Join fields (appending to current value) (#81)
+            for join_l in self.prefs.join:
+                # Each list is "target, source..." so we need at least 2 elements
+                elements = len(join_l)
+                target = join_l[0]
+                if elements > 1 and target == key:
+                    # Append data from the other fields
+                    for source in join_l[1:]:
+                        v = self.getField(source)
+                        if v:
+                            val = val + ' ' + v
+
             if val is None:
                 val = ""
             else:

--- a/kibom/preferences.py
+++ b/kibom/preferences.py
@@ -24,6 +24,7 @@ class BomPref:
     SECTION_GROUPING_FIELDS = "GROUP_FIELDS"
     SECTION_REGEXCLUDES = "REGEX_EXCLUDE"
     SECTION_REGINCLUDES = "REGEX_INCLUDE"
+    SECTION_JOIN = "JOIN"  # (#81)
 
     OPT_PCB_CONFIG = "pcb_configuration"
     OPT_NUMBER_ROWS = "number_rows"
@@ -105,6 +106,9 @@ class BomPref:
             ["d", "diode", "d_small"]
         ]
 
+        # Nothing to join by default (#81)
+        self.join = []
+
     # Check an option within the SECTION_GENERAL group
     def checkOption(self, parser, opt, default=False):
         if parser.has_option(self.SECTION_GENERAL, opt):
@@ -178,6 +182,10 @@ class BomPref:
         # Read out component aliases
         if self.SECTION_ALIASES in cf.sections():
             self.aliases = [re.split('[ \t]+', a) for a in cf.options(self.SECTION_ALIASES)]
+
+        # Read out join rules (#81)
+        if self.SECTION_JOIN in cf.sections():
+            self.join = [a.split('\t') for a in cf.options(self.SECTION_JOIN)]
 
         if self.SECTION_REGEXCLUDES in cf.sections():
             self.regExcludes = []
@@ -272,6 +280,17 @@ class BomPref:
 
         for a in self.aliases:
             cf.set(self.SECTION_ALIASES, "\t".join(a))
+
+        # (#81)
+        cf.add_section(self.SECTION_JOIN)
+        cf.set(self.SECTION_JOIN, '; A list of rules to join the content of fields')
+        cf.set(self.SECTION_JOIN, '; Each line is a rule, the first name is the field that will receive the data')
+        cf.set(self.SECTION_JOIN, '; from the other fields')
+        cf.set(self.SECTION_JOIN, '; Use tab (ASCII 9) as separator')
+        cf.set(self.SECTION_JOIN, '; Field names are case sensitive')
+
+        for a in self.join:
+            cf.set(self.SECTION_JOIN, "\t".join(a))
 
         cf.add_section(self.SECTION_REGINCLUDES)
         cf.set(self.SECTION_REGINCLUDES, '; A series of regular expressions used to include parts in the BoM')


### PR DESCRIPTION
## Description

1 nF 50 V isn't the same as 1 nF 100 V and having separated columns for
each possible modifier is an overkill. Joining the fields to the value
is compact and natural.

## How to use

Define a section named `[JOIN]`. In this section each entry is the name
of a field, followed by the name of the fields that will be added to
its column.
Use tab (ASCII 9) as separator. Example:

```
[JOIN]
Value	Voltage	Current	Power	Tolerance
```

This will attach the `voltage`, `current`, `power` and `tolerance` fields to the `value` field.

This patch replaces #81 and is smaller and more generic.