### PR TITLE
Remove alt_wrap option

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,7 +260,6 @@ Note that Digi-Key URL rendering will only be rendered for HTML file outputs.
 BoM generation options can be configured (on a per-project basis) by editing the *bom.ini* file in the PCB project directory. This file is generated the first time that the KiBoM script is run, and allows configuration of the following options.
 * `ignore_dnf` : Component groups designated as 'DNF' (do not fit) will be excluded from the BoM output
 * `use_alt` : If this option is set, grouped references will be printed in the alternate compressed style eg: R1-R7,R18
-* `alt_wrap` : If this option is set to an integer `N`, the references field will wrap after `N` entries are printed
 * `number_rows` : Add row numbers to the BoM output
 * `group_connectors` : If this option is set, connector comparison based on the 'Value' field is ignored. This allows multiple connectors which are named for their function (e.g. "Power", "ICP" etc) can be grouped together.
 * `test_regex` : If this option is set, each component group row is test against a list of (user configurable) regular expressions. If any matches are found, that row is excluded from the output BoM file.
@@ -291,8 +290,6 @@ Example configuration file (.ini format) *default values shown*
 ignore_dnf = 1
 ; If 'use_alt' option is set to 1, grouped references will be printed in the alternate compressed style eg: R1-R7,R18
 use_alt = 0
-; If 'alt_wrap' option is set to and integer N, the references field will wrap after N entries are printed
-alt_wrap = 0
 ; If 'number_rows' option is set to 1, each row in the BoM will be prepended with an incrementing row number
 number_rows = 1
 ; If 'group_connectors' option is set to 1, connectors with the same footprints will be grouped together, independent of the name of the connector

--- a/kibom/component.py
+++ b/kibom/component.py
@@ -520,14 +520,14 @@ class ComponentGroup():
         # Return a list of the components
         return " ".join([c.getRef() for c in self.components])
 
-    def getAltRefs(self, wrapN=None):
+    def getAltRefs(self):
         S = joiner()
 
         for n in self.components:
             P, N = (n.getPrefix(), n.getSuffix())
             S.add(P, N)
 
-        return S.flush(' ', N=wrapN)
+        return S.flush(' ')
 
     # Sort the components in correct order
     def sortComponents(self):

--- a/kibom/netlist_reader.py
+++ b/kibom/netlist_reader.py
@@ -354,7 +354,7 @@ class netlist():
         # Sort the references within each group
         for g in groups:
             g.sortComponents()
-            g.updateFields(self.prefs.useAlt, self.prefs.altWrap)
+            g.updateFields(self.prefs.useAlt)
 
         # Sort the groups
         # First priority is the Type of component (e.g. R?, U?, L?)

--- a/kibom/preferences.py
+++ b/kibom/preferences.py
@@ -31,7 +31,6 @@ class BomPref:
     OPT_GROUP_CONN = "group_connectors"
     OPT_USE_REGEX = "test_regex"
     OPT_USE_ALT = "use_alt"
-    OPT_ALT_WRAP = "alt_wrap"
     OPT_MERGE_BLANK = "merge_blank_fields"
     OPT_IGNORE_DNF = "ignore_dnf"
     OPT_GENERATE_DNF = "html_generate_dnf"
@@ -53,7 +52,6 @@ class BomPref:
 
         self.corder = ColumnList._COLUMNS_DEFAULT
         self.useAlt = False  # Use alternate reference representation
-        self.altWrap = None  # Wrap to n items when using alt representation
         self.ignoreDNF = True  # Ignore rows for do-not-fit parts
         self.generateDNF = True  # Generate a list of do-not-fit parts
         self.numberRows = True  # Add row-numbers to BoM output
@@ -137,7 +135,6 @@ class BomPref:
             self.ignoreDNF = self.checkOption(cf, self.OPT_IGNORE_DNF, default=True)
             self.generateDNF = self.checkOption(cf, self.OPT_GENERATE_DNF, default=True)
             self.useAlt = self.checkOption(cf, self.OPT_USE_ALT, default=False)
-            self.altWrap = self.checkInt(cf, self.OPT_ALT_WRAP, default=None)
             self.numberRows = self.checkOption(cf, self.OPT_NUMBER_ROWS, default=True)
             self.groupConnectors = self.checkOption(cf, self.OPT_GROUP_CONN, default=True)
             self.useRegex = self.checkOption(cf, self.OPT_USE_REGEX, default=True)
@@ -218,7 +215,6 @@ class BomPref:
         self.addOption(cf, self.OPT_IGNORE_DNF, self.ignoreDNF, comment="If '{opt}' option is set to 1, rows that are not to be fitted on the PCB will not be written to the BoM file".format(opt=self.OPT_IGNORE_DNF))
         self.addOption(cf, self.OPT_GENERATE_DNF, self.generateDNF, comment="If '{opt}' option is set to 1, also generate a list of components not fitted on the PCB (HTML only)".format(opt=self.OPT_GENERATE_DNF))
         self.addOption(cf, self.OPT_USE_ALT, self.useAlt, comment="If '{opt}' option is set to 1, grouped references will be printed in the alternate compressed style eg: R1-R7,R18".format(opt=self.OPT_USE_ALT))
-        self.addOption(cf, self.OPT_ALT_WRAP, self.altWrap, comment="If '{opt}' option is set to and integer N, the references field will wrap after N entries are printed".format(opt=self.OPT_ALT_WRAP))
         self.addOption(cf, self.OPT_NUMBER_ROWS, self.numberRows, comment="If '{opt}' option is set to 1, each row in the BoM will be prepended with an incrementing row number".format(opt=self.OPT_NUMBER_ROWS))
         self.addOption(cf, self.OPT_GROUP_CONN, self.groupConnectors, comment="If '{opt}' option is set to 1, connectors with the same footprints will be grouped together, independent of the name of the connector".format(opt=self.OPT_GROUP_CONN))
         self.addOption(cf, self.OPT_USE_REGEX, self.useRegex, comment="If '{opt}' option is set to 1, each component group will be tested against a number of regular-expressions (specified, per column, below). If any matches are found, the row is ignored in the output file".format(opt=self.OPT_USE_REGEX))


### PR DESCRIPTION
The alt_wrap option is not supported for all output formats, is error-prone, and poorly documented.

Removing as it is not super useful and is difficult to maintain.