### PR TITLE
Add a mechanism to rename columns

### DIFF
--- a/kibom/bom_writer.py
+++ b/kibom/bom_writer.py
@@ -38,7 +38,9 @@ def WriteBoM(filename, groups, net, headings=columns.ColumnList._COLUMNS_DEFAULT
         prefs = BomPref()
 
     # Remove any headings that appear in the ignore[] list
-    headings = [h for h in headings if not h.lower() in [i.lower() for i in prefs.ignore]]
+    headings = [h for h in headings if not h.lower() in prefs.ignore]
+    # Allow renaming the columns
+    head_names = [h if h.lower() not in prefs.colRename else prefs.colRename[h.lower()] for h in headings]
 
     # If no extension is given, assume .csv (and append!)
     if len(filename.split('.')) < 2:
@@ -54,28 +56,28 @@ def WriteBoM(filename, groups, net, headings=columns.ColumnList._COLUMNS_DEFAULT
 
     # CSV file writing
     if ext in ["csv", "tsv", "txt"]:
-        if WriteCSV(filename, groups, net, headings, prefs):
+        if WriteCSV(filename, groups, net, headings, head_names, prefs):
             debug.info("CSV Output -> {fn}".format(fn=filename))
             result = True
         else:
             debug.error("Error writing CSV output")
 
     elif ext in ["htm", "html"]:
-        if WriteHTML(filename, groups, net, headings, prefs):
+        if WriteHTML(filename, groups, net, headings, head_names, prefs):
             debug.info("HTML Output -> {fn}".format(fn=filename))
             result = True
         else:
             debug.error("Error writing HTML output")
 
     elif ext in ["xml"]:
-        if WriteXML(filename, groups, net, headings, prefs):
+        if WriteXML(filename, groups, net, headings, head_names, prefs):
             debug.info("XML Output -> {fn}".format(fn=filename))
             result = True
         else:
             debug.error("Error writing XML output")
 
     elif ext in ["xlsx"]:
-        if WriteXLSX(filename, groups, net, headings, prefs):
+        if WriteXLSX(filename, groups, net, headings, head_names, prefs):
             debug.info("XLSX Output -> {fn}".format(fn=filename))
             result = True
         else:

--- a/kibom/component.py
+++ b/kibom/component.py
@@ -496,7 +496,7 @@ class joiner:
             if bool(N) and c != 0 and c % N == 0:
                 refstr += u'\n'
             elif c != 0:
-                refstr += sep+" "
+                refstr += sep + " "
 
             S, E = Q
 

--- a/kibom/csv_writer.py
+++ b/kibom/csv_writer.py
@@ -5,13 +5,14 @@ import os
 import sys
 
 
-def WriteCSV(filename, groups, net, headings, prefs):
+def WriteCSV(filename, groups, net, headings, head_names, prefs):
     """
     Write BoM out to a CSV file
     filename = path to output file (must be a .csv, .txt or .tsv file)
     groups = [list of ComponentGroup groups]
     net = netlist object
-    headings = [list of headings to display in the BoM file]
+    headings = [list of headings to search for data in the BoM file]
+    head_names = [list of headings to display in the BoM file]
     prefs = BomPref object
     """
 
@@ -43,9 +44,12 @@ def WriteCSV(filename, groups, net, headings, prefs):
 
     if not prefs.hideHeaders:
         if prefs.numberRows:
-            writer.writerow(["Component"] + headings)
+            comp = "Component"
+            if comp.lower() in prefs.colRename:
+                comp = prefs.colRename[comp.lower()]
+            writer.writerow([comp] + head_names)
         else:
-            writer.writerow(headings)
+            writer.writerow(head_names)
 
     count = 0
     rowCount = 1

--- a/kibom/html_writer.py
+++ b/kibom/html_writer.py
@@ -32,13 +32,14 @@ def link(text):
     return text
 
 
-def WriteHTML(filename, groups, net, headings, prefs):
+def WriteHTML(filename, groups, net, headings, head_names, prefs):
     """
     Write BoM out to a HTML file
     filename = path to output file (must be a .htm or .html file)
     groups = [list of ComponentGroup groups]
     net = netlist object
-    headings = [list of headings to display in the BoM file]
+    headings = [list of headings to search for data in the BoM file]
+    head_names = [list of headings to display in the BoM file]
     prefs = BomPref object
     """
 
@@ -99,9 +100,9 @@ def WriteHTML(filename, groups, net, headings, prefs):
         if prefs.numberRows:
             html.write("\t<th></th>\n")
 
-        for i, h in enumerate(headings):
+        for i, h in enumerate(head_names):
             # Cell background color
-            bg = bgColor(h)
+            bg = bgColor(headings[i])
             html.write('\t<th align="center"{bg}>{h}</th>\n'.format(
                 h=h,
                 bg=' bgcolor="{c}"'.format(c=bg) if bg else '')
@@ -151,9 +152,9 @@ def WriteHTML(filename, groups, net, headings, prefs):
             html.write("<tr>\n")
             if prefs.numberRows:
                 html.write("\t<th></th>\n")
-            for i, h in enumerate(headings):
+            for i, h in enumerate(head_names):
                 # Cell background color
-                bg = bgColor(h)
+                bg = bgColor(headings[i])
                 html.write('\t<th align="center"{bg}>{h}</th>\n'.format(h=h, bg=' bgcolor="{c}"'.format(c=bg) if bg else ''))
             html.write("</tr>\n")
  

--- a/kibom/xlsx_writer.py
+++ b/kibom/xlsx_writer.py
@@ -3,7 +3,7 @@
 try:
     import xlsxwriter
 except:
-    def WriteXLSX(filename, groups, net, headings, prefs):
+    def WriteXLSX(filename, groups, net, headings, head_names, prefs):
         return False
 else:
     import os
@@ -13,11 +13,12 @@ else:
     filename = path to output file (must be a .xlsx file)
     groups = [list of ComponentGroup groups]
     net = netlist object
-    headings = [list of headings to display in the BoM file]
+    headings = [list of headings to search for data in the BoM file]
+    head_names = [list of headings to display in the BoM file]
     prefs = BomPref object
     """
 
-    def WriteXLSX(filename, groups, net, headings, prefs):
+    def WriteXLSX(filename, groups, net, headings, head_names, prefs):
 
         filename = os.path.abspath(filename)
 
@@ -33,9 +34,12 @@ else:
         worksheet = workbook.add_worksheet()
 
         if prefs.numberRows:
-            row_headings = ["Component"] + headings
+            comp = "Component"
+            if comp.lower() in prefs.colRename:
+                comp = prefs.colRename[comp.lower()]
+            row_headings = [comp] + head_names
         else:
-            row_headings = headings
+            row_headings = head_names
 
         cellformats = {}
         column_widths = {}

--- a/kibom/xml_writer.py
+++ b/kibom/xml_writer.py
@@ -14,7 +14,7 @@ from xml.etree import ElementTree
 from xml.dom import minidom
 
 
-def WriteXML(filename, groups, net, headings, prefs):
+def WriteXML(filename, groups, net, headings, head_names, prefs):
 
     if not filename.endswith(".xml"):
         return False
@@ -49,7 +49,7 @@ def WriteXML(filename, groups, net, headings, prefs):
 
         attrib = {}
 
-        for i, h in enumerate(headings):
+        for i, h in enumerate(head_names):
             h = h.replace(' ', '_')  # Replace spaces, xml no likey
             h = h.replace('"', '')
             h = h.replace("'", '')


### PR DESCRIPTION
## Description

Column names displayed in the table head are the names of the KiCad fields or the internal names used by KiBoM.
Sometimes the names aren't pretty. As an example is common to use `manf#` for the part name used by the component manufacturer.
Using long names for KiCad fields is a bad idea.

This patch allows to rename the columns names so you can use pretty names in the headings.

You must define a `COLUMN_RENAME` section in the configuration file.
Then add entries with the name of the original field and the name you want, separated by a tab (ASCII 9).
Here is an example:

```
[COLUMN_RENAME]
manf#	Manufacturer part number
```

Note that you must use a tab as separator. Using a space won't work because *Manufacturer part number* also has spaces.

## Limitations

The separator must be a tab.

## Additional notes

- This patch also makes the `prefs.ignore` list lowercase.
  This is to avoid converting it to lower case all the time.
- `prefs.colRename` is a hash. I saw that various preference options should also be a *dict* instead of a *list*.