### PR TITLE
Fix Python 2 issues

### DIFF
--- a/kibom/component.py
+++ b/kibom/component.py
@@ -193,7 +193,8 @@ class Component():
             except AttributeError:
                 # Raise a good error description here, so the user knows what the culprit component is.
                 # (sometimes libpart is None)
-                raise AttributeError(f'Could not get description for part {self.getPrefix()}{self.getSuffix()}.')
+                raise AttributeError('Could not get description for part {}{}.'.format(self.getPrefix()),
+                                     self.getSuffix())
 
         return ret
 

--- a/kibom/preferences.py
+++ b/kibom/preferences.py
@@ -122,6 +122,12 @@ class BomPref:
         else:
             return default
 
+    def checkStr(self, opt, default=False):
+        if self.parser.has_option(self.SECTION_GENERAL, opt):
+            return self.parser.get(self.SECTION_GENERAL, opt)
+        else:
+            return default
+
     # Read KiBOM preferences from file
     def Read(self, file, verbose=False):
         file = os.path.abspath(file)
@@ -130,6 +136,7 @@ class BomPref:
             return
 
         cf = ConfigParser.RawConfigParser(allow_no_value=True)
+        self.parser = cf
         cf.optionxform = str
 
         cf.read(file)
@@ -143,10 +150,9 @@ class BomPref:
             self.groupConnectors = self.checkOption(cf, self.OPT_GROUP_CONN, default=True)
             self.useRegex = self.checkOption(cf, self.OPT_USE_REGEX, default=True)
             self.mergeBlankFields = self.checkOption(cf, self.OPT_MERGE_BLANK, default=True)
-            self.outputFileName = cf.get(self.SECTION_GENERAL, self.OPT_OUTPUT_FILE_NAME,
-                                         fallback=self.outputFileName)
-            self.variantFileNameFormat = cf.get(self.SECTION_GENERAL, self.OPT_VARIANT_FILE_NAME_FORMAT,
-                                                fallback=self.variantFileNameFormat)
+            self.outputFileName = self.checkStr(self.OPT_OUTPUT_FILE_NAME, default=self.outputFileName)
+            self.variantFileNameFormat = self.checkStr(self.OPT_VARIANT_FILE_NAME_FORMAT,
+                                                       default=self.variantFileNameFormat)
 
         if cf.has_option(self.SECTION_GENERAL, self.OPT_CONFIG_FIELD):
             self.configField = cf.get(self.SECTION_GENERAL, self.OPT_CONFIG_FIELD)


### PR DESCRIPTION
This patch fixes two Python 2.7 compatibility issues:

- The ConfigParser `fallback`, introduced in Python 3. Introduced by me on PR #121
- The use of f-strings in PR #127, they need Python 3.6 or newer

Note that for the first I introduced a helpful member checkStr, it was designed to be used in various places, but this is part of a bigger patch delayed by PR #112 an #120. The patch also fixes #123.
To get an idea the patch is INTI-CMNB/kibom#11