### PR TITLE
Fixed utf-8 bug in the XML writer.

### DIFF
--- a/kibom/xml_writer.py
+++ b/kibom/xml_writer.py
@@ -60,6 +60,9 @@ def WriteXML(filename, groups, net, headings, prefs):
 
     with open(filename, "w") as output:
         out = ElementTree.tostring(xml, encoding="utf-8")
-        output.write(minidom.parseString(out).toprettyxml(indent="\t"))
+        # There is probably a better way to write the data to file (without so many encoding/decoding steps),
+        # but toprettyxml() without specifying UTF-8 will chew up non-ASCII chars. Perhaps revisit if performance here
+        # is ever a concern
+        output.write(minidom.parseString(out).toprettyxml(indent="\t", encoding="utf-8").decode("utf-8"))
 
     return True


### PR DESCRIPTION
I noticed than non-ASCII characters (e.g. `±` when component tolerances) were getting destroyed when generating an `.xml` BOM. The fix was to specify the encoding when calling `toprettyxml()`, and then call `.decode('utf-8')` to get the bytes back into a Python string suitable to `output.write()`.

Oh and sorry about my previous pull-request that used `f-strings`, I didn't realize Python 2 was supported. I then noticed that KiCAD for Windows is still bundled with Python 2 :-).