### PR TITLE
Reference Designator Separators

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,6 +275,7 @@ BoM generation options can be configured (on a per-project basis) by editing the
 * `group_connectors` : If this option is set, connector comparison based on the 'Value' field is ignored. This allows multiple connectors which are named for their function (e.g. "Power", "ICP" etc) can be grouped together.
 * `test_regex` : If this option is set, each component group row is test against a list of (user configurable) regular expressions. If any matches are found, that row is excluded from the output BoM file.
 * `merge_blank_field` : If this option is set, blank fields are able to be merged with non-blank fields (and do not count as a 'conflict')
+* `ref_separator` : This is the character used to separate reference designators in the output, when grouped. Defaults to " ".
 * `fit_field` : This is the name of the part field used to determine if the component is fitted, or not.
 * `output_file_name` : A string that allows arbitrary specification of the output file name with field replacements. Fields available:
     - `%O` : The base output file name (pulled from kicad, or specified on command line when calling script).

--- a/kibom/component.py
+++ b/kibom/component.py
@@ -546,7 +546,13 @@ class ComponentGroup():
 
     def getRefs(self):
         # Return a list of the components
-        return " ".join([c.getRef() for c in self.components])
+        separator = self.prefs.refSeparator
+        # separator = separator[0]
+        # if len(separator) > 1:
+            # separator = separator[1]
+        # else:
+            # separator = separator[0]
+        return separator.join([c.getRef() for c in self.components])
 
     def getAltRefs(self):
         S = joiner()

--- a/kibom/component.py
+++ b/kibom/component.py
@@ -547,11 +547,6 @@ class ComponentGroup():
     def getRefs(self):
         # Return a list of the components
         separator = self.prefs.refSeparator
-        # separator = separator[0]
-        # if len(separator) > 1:
-            # separator = separator[1]
-        # else:
-            # separator = separator[0]
         return separator.join([c.getRef() for c in self.components])
 
     def getAltRefs(self):

--- a/kibom/preferences.py
+++ b/kibom/preferences.py
@@ -43,6 +43,7 @@ class BomPref:
     OPT_CONFIG_FIELD = "fit_field"
     OPT_HIDE_HEADERS = "hide_headers"
     OPT_HIDE_PCB_INFO = "hide_pcb_info"
+    OPT_REF_SEPARATOR = "ref_separator"
 
     def __init__(self):
         # List of headings to ignore in BoM generation
@@ -67,6 +68,7 @@ class BomPref:
         self.hidePcbInfo = False
         self.configField = "Config"  # Default field used for part fitting config
         self.pcbConfig = ["default"]
+        self.refSeparator = " "
 
         self.backup = "%O.tmp"
 
@@ -154,6 +156,7 @@ class BomPref:
             self.outputFileName = self.checkStr(self.OPT_OUTPUT_FILE_NAME, default=self.outputFileName)
             self.variantFileNameFormat = self.checkStr(self.OPT_VARIANT_FILE_NAME_FORMAT,
                                                        default=self.variantFileNameFormat)
+            self.refSeparator = self.checkStr(self.OPT_REF_SEPARATOR, default=self.refSeparator).strip("\'\"")
 
         if cf.has_option(self.SECTION_GENERAL, self.OPT_CONFIG_FIELD):
             self.configField = cf.get(self.SECTION_GENERAL, self.OPT_CONFIG_FIELD)
@@ -245,6 +248,9 @@ class BomPref:
 
         cf.set(self.SECTION_GENERAL, '; Field name used to determine if a particular part is to be fitted')
         cf.set(self.SECTION_GENERAL, self.OPT_CONFIG_FIELD, self.configField)
+
+        cf.set(self.SECTION_GENERAL, '; Character used to separate reference designators in output')
+        cf.set(self.SECTION_GENERAL, self.OPT_REF_SEPARATOR, self.refSeparator)
 
         cf.set(self.SECTION_GENERAL, '; Make a backup of the bom before generating the new one, using the following template')
         cf.set(self.SECTION_GENERAL, self.OPT_BACKUP, self.backup)


### PR DESCRIPTION
When reference designators are grouped on a single line in the output file, they are separated by a hard-coded space character. Some PCB assembly services want different characters (primarily ",") to separate the reference designators. This pull request creates a configuration file option "ref_separator" that defaults to the original hard-coded space but can be changed to a comma or anything else needed by adding a line to the configuration file.

	modified:   ../README.md
	modified:   component.py
	modified:   preferences.py