### PR TITLE
Fixed the ref_separator save, must be quoted.

### DIFF
--- a/kibom/preferences.py
+++ b/kibom/preferences.py
@@ -250,7 +250,7 @@ class BomPref:
         cf.set(self.SECTION_GENERAL, self.OPT_CONFIG_FIELD, self.configField)
 
         cf.set(self.SECTION_GENERAL, '; Character used to separate reference designators in output')
-        cf.set(self.SECTION_GENERAL, self.OPT_REF_SEPARATOR, self.refSeparator)
+        cf.set(self.SECTION_GENERAL, self.OPT_REF_SEPARATOR, "'" + self.refSeparator + "'")
 
         cf.set(self.SECTION_GENERAL, '; Make a backup of the bom before generating the new one, using the following template')
         cf.set(self.SECTION_GENERAL, self.OPT_BACKUP, self.backup)


### PR DESCRIPTION
A small detail. 
If we don't quote it the generated file will be read as `ref_separator = ''`