### PR TITLE
Updated to the offical kicad.org url

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![PyPi version](https://pypip.in/v/kibom/badge.png)](https://pypi.org/project/kibom/) [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)  [![Travis Status](https://api.travis-ci.org/SchrodingersGat/KiBoM.svg?branch=master)](https://travis-ci.org/SchrodingersGat/KiBoM)  [![Coverage Status](https://coveralls.io/repos/github/SchrodingersGat/KiBoM/badge.svg?branch=master)](https://coveralls.io/github/SchrodingersGat/KiBoM?branch=master)
 
-Configurable BoM generation tool for KiCad EDA (http://kicad-pcb.org/)
+Configurable BoM generation tool for KiCad EDA (http://kicad.org/)
 
 ## Description
 


### PR DESCRIPTION
The old domain is now not associated with the KiCad project.
https://forum.kicad.info/t/warning-avoid-all-links-to-kicad-pcb-org-use-kicad-org/31521

@SchrodingersGat Also please consider changing the project description here on github.
![image](https://user-images.githubusercontent.com/4141691/138118872-6bd69fc6-55f6-4065-ae55-22828984e40f.png)
