### PR TITLE
Try different capitalization for Description field

### DIFF
--- a/kibom/component.py
+++ b/kibom/component.py
@@ -191,6 +191,10 @@ class Component():
         if ret:
             return ret
 
+        ret = self.element.get("field", "name", "Description")
+        if ret:
+            return ret
+
         try:
             ret = self.element.get("libsource", "description")
         except:


### PR DESCRIPTION
When getting the description of a component, if "description" does not exist, look for "Description" instead. I noticed that when using KiCAD 7, my generated BOM was missing a lot of information. I'm not sure if the right thing to do is simply to make this case-insensitive, or simply to check a few different options. In my project, I have several parts libraries from various sources (Ultra Librarian, SnapEDA, Component Search Engine), and the fields associated with the parts vary quite a bit; this change worked well for my use case.

This builds off of #177, and seems to resolve issue #178.