### PR TITLE
Exclude components marked as "Exclude from BoM"

### DIFF
--- a/kibom/component.py
+++ b/kibom/component.py
@@ -354,7 +354,8 @@ class Component():
         # First, check for the 'dnp' attribute (added in KiCad 7.0)
         for child in self.element.getChildren():
             if child.name == 'property':
-                if child.attributes.get('name', '').lower() == 'dnp':
+                name = child.attributes.get('name', '').lower()
+                if name == 'dnp' or name == 'exclude_from_bom':
                     return False
 
         # Check the value field first


### PR DESCRIPTION
Note that this flag can't be seen on files generated using the GUI and asking to create a BoM.
But if you ask to export the netlist using the XML format, i.e. using kicad-cli, you'll get the components listed.
Also note that the same happens with the DNP flag!