### PR TITLE
Added a command line option to exclude `:` as INI delimiter

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,8 @@ optional arguments:
                         not specified here)
   -s SEPARATOR, --separator SEPARATOR
                         CSV Separator (default ',')
+  -k, --no-colon-sep    Don't use : as delimiter in the config file
+  --version             show program's version number and exit
 
 
 ~~~~                        
@@ -97,6 +99,8 @@ optional arguments:
 **--cfg** If provided, this is the BoM config file that will be used. If not provided, options will be loaded from "bom.ini"
 
 **-s --separator** Override the delimiter for CSV or TSV generation
+
+**-k --no-colon-sep** Only accept `=` as a delimiter for KEY/VALUE pairs in the config file, enables the use of `:` in field names
 
 --------
 To run from KiCad, simply add the same command line in the *Bill of Materials* script window. e.g. to generate a HTML output:

--- a/kibom/__main__.py
+++ b/kibom/__main__.py
@@ -165,6 +165,7 @@ def main():
     parser.add_argument("-d", "--subdirectory", help="Subdirectory within which to store the generated BoM files.", type=str, default=None)
     parser.add_argument("--cfg", help="BoM config file (script will try to use 'bom.ini' if not specified here)")
     parser.add_argument("-s", "--separator", help="CSV Separator (default ',')", type=str, default=None)
+    parser.add_argument("-k", "--no-colon-sep", help="Don't use : as delimiter in the config file", action='store_true')
     parser.add_argument('--version', action='version', version="KiBOM Version: {v}".format(v=KIBOM_VERSION))
 
     args = parser.parse_args()
@@ -221,7 +222,7 @@ def main():
     have_cfile = os.path.exists(config_file)
 
     if have_cfile:
-        pref.Read(config_file)
+        pref.Read(config_file, no_colon_sep=args.no_colon_sep)
         debug.message("Configuration file:", config_file)
     else:
         pref.Write(config_file)

--- a/kibom/preferences.py
+++ b/kibom/preferences.py
@@ -143,13 +143,13 @@ class BomPref:
             return default
 
     # Read KiBOM preferences from file
-    def Read(self, file, verbose=False):
+    def Read(self, file, verbose=False, no_colon_sep=False):
         file = os.path.abspath(file)
         if not os.path.exists(file) or not os.path.isfile(file):
             debug.error("{f} is not a valid file!".format(f=file))
             return
 
-        cf = ConfigParser.RawConfigParser(allow_no_value=True)
+        cf = ConfigParser.RawConfigParser(allow_no_value=True, delimiters=('=') if no_colon_sep else ('=', ':'))
         self.parser = cf
         cf.optionxform = str
 


### PR DESCRIPTION
Allows things like KiCost:Field used as field name.

This is important to interact with KiCost because it supports things like *KiCost:Distributor:pricing* to specify the *pricing* for a local *Distributor*.

The .INI file will parse the `:` as a key/value delimiter and you'll get *KiCost*, instead of the full name, for places like **IGNORE_COLUMNS**. 

See INTI-CMNB/KiBoM#20