### PR TITLE
Fixed changing field values via the complex_variant option

### DIFF
--- a/kibom/component.py
+++ b/kibom/component.py
@@ -240,16 +240,17 @@ class Component():
     def setField(self, name, value):
         """ Set the value of the specified field """
 
+        name = name.lower()
         # Description field
         doc = self.element.getChild('libsource')
         if doc:
             for att_name, att_value in doc.attributes.items():
-                if att_name.lower() == name.lower():
+                if att_name.lower() == name:
                     doc.attributes[att_name] = value
                     return value
 
         # Common fields
-        field = self.element.getChild(name.lower())
+        field = self.element.getChild(name)
         if field:
             field.setChars(value)
             return value
@@ -258,7 +259,7 @@ class Component():
         fields = self.element.getChild('fields')
         if fields:
             for field in fields.getChildren():
-                if field.get('field', 'name') == name:
+                if field.get('field', 'name').lower() == name:
                     field.setChars(value)
                     return value
 


### PR DESCRIPTION
This is just a "backport" of the INTI-CMNB/KiBoM#23 PR by @PatrickBaus 

Replacing field values using the complex_variant = True option is not case sensitive.

If the field name to be replaced contains uppercase letters, the comparison will fail because of the following code

```python
if field.get('field', 'name') == name:
```

The first part of the comparison may contain uppercase letters. The latter part is typically lower case, but for safety reasons, I apply lower() as well. This PR contains the fix and also squashes some trailing white spaces.